### PR TITLE
Add root health endpoint

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -7,6 +7,15 @@ models.Base.metadata.create_all(bind=database.engine)
 app = FastAPI()
 
 
+@app.get("/")
+def read_root():
+    """Simple health check endpoint.
+
+    Returns a friendly message indicating the API is running.
+    """
+    return {"message": "NodeProbe API is running"}
+
+
 def get_db():
     db = database.SessionLocal()
     try:


### PR DESCRIPTION
## Summary
- add root `/` route that returns a simple message so hitting the server no longer returns `Not Found`

## Testing
- `pytest`
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_6894018d3254832ab16ecd3188a55219