### PR TITLE
feat: collect and display client info

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -1,6 +1,7 @@
-from fastapi import FastAPI, Depends
+from fastapi import FastAPI, Depends, Request
 from fastapi.middleware.cors import CORSMiddleware
 from sqlalchemy.orm import Session
+import requests
 from . import models, schemas, database
 
 models.Base.metadata.create_all(bind=database.engine)
@@ -40,8 +41,27 @@ def read_tests(db: Session = Depends(get_db)):
 
 
 @app.post("/tests", response_model=schemas.TestRecord)
-def create_test(record: schemas.TestRecordCreate, db: Session = Depends(get_db)):
-    db_record = models.TestRecord(**record.dict())
+def create_test(
+    record: schemas.TestRecordCreate, request: Request, db: Session = Depends(get_db)
+):
+    data = record.dict()
+    client_ip = request.client.host
+    data.setdefault("client_ip", client_ip)
+
+    if not data.get("location") or not data.get("asn") or not data.get("isp"):
+        try:
+            resp = requests.get(f"https://ipapi.co/{client_ip}/json/")
+            if resp.ok:
+                geo = resp.json()
+                data.setdefault(
+                    "location", f"{geo.get('city')}, {geo.get('country_name')}"
+                )
+                data.setdefault("asn", geo.get("asn"))
+                data.setdefault("isp", geo.get("org"))
+        except Exception:
+            pass
+
+    db_record = models.TestRecord(**data)
     db.add(db_record)
     db.commit()
     db.refresh(db_record)

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -2,3 +2,4 @@ fastapi
 uvicorn
 sqlalchemy
 pydantic
+requests

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -14,47 +14,38 @@ interface TestRecord {
 }
 
 function App() {
-  const [tests, setTests] = useState<TestRecord[]>([]);
-
-  const loadTests = async () => {
-    try {
-      const res = await fetch('/tests');
-      setTests(await res.json());
-    } catch (err) {
-      console.error('Failed to load tests', err);
-    }
-  };
+  const [info, setInfo] = useState<TestRecord | null>(null);
 
   useEffect(() => {
-    loadTests();
+    const collect = async () => {
+      try {
+        const res = await fetch('/tests', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: '{}',
+        });
+        setInfo(await res.json());
+      } catch (err) {
+        console.error('Failed to collect info', err);
+      }
+    };
+    collect();
   }, []);
 
-  const startTest = async () => {
-    try {
-      await fetch('/tests', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        // For now send minimal mock data. Real implementation should
-        // collect actual network diagnostics here.
-        body: JSON.stringify({ ping_ms: Math.random() * 100 }),
-      });
-      await loadTests();
-    } catch (err) {
-      console.error('Failed to create test record', err);
-    }
-  };
-
   return (
-    <div className="min-h-screen bg-gradient-to-br from-black via-purple-900 to-indigo-900 text-green-400 flex flex-col items-center justify-center gap-4 p-4">
-      <button
-        onClick={startTest}
-        className="px-6 py-3 border border-green-400 hover:bg-green-400 hover:text-black transition"
-      >
-        Start Test
-      </button>
-      <pre className="w-full max-w-3xl bg-black/50 p-4 overflow-auto rounded-md">
-        {JSON.stringify(tests, null, 2)}
-      </pre>
+    <div className="min-h-screen bg-gradient-to-br from-black via-purple-900 to-indigo-900 text-green-400 flex items-center justify-center p-4">
+      {info ? (
+        <div className="space-y-2 text-center">
+          <h1 className="text-xl mb-4">Your Connection Info</h1>
+          <div>IP: {info.client_ip}</div>
+          {info.location && <div>Location: {info.location}</div>}
+          {info.asn && <div>ASN: {info.asn}</div>}
+          {info.isp && <div>ISP: {info.isp}</div>}
+          <div className="text-sm text-gray-400">Recorded at: {new Date(info.timestamp).toLocaleString()}</div>
+        </div>
+      ) : (
+        <div>Loading...</div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- auto-record client IP and location when creating test records
- default frontend page posts to /tests on load and shows visitor info
- add requests dependency

## Testing
- `npm test` *(fails: Missing script "test")*
- `python -m py_compile backend/main.py`


------
https://chatgpt.com/codex/tasks/task_e_689405f32824832a8a75d3965caa8b9b