### PR TITLE
feat: align data directory with project name

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ cd NodeProbe
 docker compose up -d
 ```
 
-默认数据会存储在 `/opt/nodeprobe/data/` 下。
+默认数据会存储在 `/opt/NodeProbe/data/` 下。
 
 访问示例：
 
@@ -58,8 +58,8 @@ chmod +x ./NodeProbe/deploy.sh
 ```bash
 docker pull ghcr.io/podcctv/nodeprobe:latest
 docker run -d --name nodeprobe -p 8000:8000 \
-  -v /opt/nodeprobe/data:/app/data \
+  -v /opt/NodeProbe/data:/app/data \
   ghcr.io/podcctv/nodeprobe:latest
 ```
 
-默认数据同样会保存到 `/opt/nodeprobe/data/`。
+默认数据同样会保存到 `/opt/NodeProbe/data/`。

--- a/deploy.sh
+++ b/deploy.sh
@@ -3,7 +3,8 @@ set -e
 
 # Absolute path of script
 BASE_DIR="$(cd "$(dirname "$0")" && pwd)"
-DATA_DIR="/opt/nodeprobe/data"
+# Use a persistent data directory that matches the project name
+DATA_DIR="/opt/NodeProbe/data"
 
 mkdir -p "$DATA_DIR"
 cd "$BASE_DIR"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,5 +4,5 @@ services:
     ports:
       - "8000:8000"
     volumes:
-      - /opt/nodeprobe/data:/app/data
+      - /opt/NodeProbe/data:/app/data
     restart: unless-stopped


### PR DESCRIPTION
## Summary
- point persistent data path to `/opt/NodeProbe/data`
- update docs and scripts to match project directory casing

## Testing
- `bash -n deploy.sh`
- `python -m py_compile backend/*.py`
- `docker-compose config`


------
https://chatgpt.com/codex/tasks/task_e_68940c6bc49c832aaa0c2ec5f2e279b3