### PR TITLE
feat: add default homepage

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -3,3 +3,5 @@ uvicorn
 sqlalchemy
 pydantic
 requests
+jinja2
+httpx

--- a/backend/templates/index.html
+++ b/backend/templates/index.html
@@ -1,0 +1,58 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>NodeProbe</title>
+    <style>
+      body {
+        font-family: sans-serif;
+        background: #111;
+        color: #0f0;
+        padding: 1rem;
+      }
+      h1, h2 {
+        color: #0f0;
+      }
+      input, button {
+        padding: 0.4rem;
+        margin: 0.2rem;
+      }
+      pre {
+        background: #000;
+        padding: 0.5rem;
+        overflow-x: auto;
+      }
+    </style>
+  </head>
+  <body>
+    <h1>Your Connection Info</h1>
+    <ul>
+      <li>IP: {{ info.client_ip }}</li>
+      {% if info.location %}<li>Location: {{ info.location }}</li>{% endif %}
+      {% if info.asn %}<li>ASN: {{ info.asn }}</li>{% endif %}
+      {% if info.isp %}<li>ISP: {{ info.isp }}</li>{% endif %}
+      <li>Recorded at: {{ info.timestamp }}</li>
+    </ul>
+
+    <h2>Recent Tests</h2>
+    <ul>
+      {% for r in records %}
+      <li>{{ r.client_ip }} - {{ r.location or 'Unknown' }} - {{ r.timestamp }}</li>
+      {% endfor %}
+    </ul>
+
+    <h2>Manual Ping Test</h2>
+    <input id="host" value="8.8.8.8" />
+    <button onclick="runPing()">Ping</button>
+    <pre id="ping-output"></pre>
+
+    <script>
+      async function runPing() {
+        const host = document.getElementById('host').value;
+        const res = await fetch('/ping?host=' + encodeURIComponent(host));
+        const data = await res.json();
+        document.getElementById('ping-output').textContent = data.output || data.error || 'No output';
+      }
+    </script>
+  </body>
+</html>

--- a/backend/test_main.py
+++ b/backend/test_main.py
@@ -1,0 +1,15 @@
+from fastapi.testclient import TestClient
+
+from backend.main import app
+
+client = TestClient(app)
+
+
+def test_homepage_creates_record_and_returns_html():
+    res = client.get("/")
+    assert res.status_code == 200
+    assert "Your Connection Info" in res.text
+
+    res_records = client.get("/tests")
+    data = res_records.json()
+    assert data.get("records")


### PR DESCRIPTION
## Summary
- serve a simple HTML homepage that records visitor info and shows recent tests
- add dependencies and tests for new template-based frontend

## Testing
- `pytest`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68941a14acb4832a8e23fe8a7312cb68