### PR TITLE
Add traceroute diagnostics and improve ping handling

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,9 @@ RUN npm run build
 FROM python:3.11-slim
 WORKDIR /app
 COPY backend/requirements.txt ./backend/requirements.txt
-RUN pip install --no-cache-dir -r backend/requirements.txt
+RUN apt-get update && apt-get install -y --no-install-recommends iputils-ping traceroute \
+    && rm -rf /var/lib/apt/lists/* \
+    && pip install --no-cache-dir -r backend/requirements.txt
 
 # Copy application source
 COPY backend ./backend

--- a/README.md
+++ b/README.md
@@ -15,6 +15,11 @@ Lightweight self-hosted probe service for testing global connectivity to a targe
 
 The script installs dependencies and launches the FastAPI server together with the Vite development server.
 
+The backend exposes simple diagnostic endpoints:
+
+- `GET /ping?host=example.com` to run ICMP tests
+- `GET /traceroute?host=example.com` to trace network routes (add `&download=true` to get a text file)
+
 ## Docker 化部署
 
 本项目已支持一键部署，整合所有必要服务：

--- a/backend/test_main.py
+++ b/backend/test_main.py
@@ -13,3 +13,17 @@ def test_homepage_creates_record_and_returns_html():
     res_records = client.get("/tests")
     data = res_records.json()
     assert data.get("records")
+
+
+def test_ping_endpoint_localhost():
+    res = client.get("/ping", params={"host": "127.0.0.1", "count": 1})
+    data = res.json()
+    assert "output" in data
+    assert "ttl" in data["output"]
+
+
+def test_traceroute_endpoint_download():
+    res = client.get("/traceroute", params={"host": "127.0.0.1", "download": "true"})
+    assert res.status_code == 200
+    disposition = res.headers.get("content-disposition", "")
+    assert "traceroute_127.0.0.1.txt" in disposition


### PR DESCRIPTION
## Summary
- install ping and traceroute in backend image
- add traceroute endpoint with optional file download
- improve ping error message and document diagnostics endpoints

## Testing
- `pytest`
- `python - <<'PY'
from backend.main import run_ping, run_traceroute
print('Ping localhost:', run_ping('127.0.0.1',1))
print('Ping 8.8.8.8:', run_ping('8.8.8.8',1))
tr = run_traceroute('127.0.0.1')
print('Traceroute localhost output lines:', tr['output'].splitlines()[:3])
PY`

------
https://chatgpt.com/codex/tasks/task_e_68941bc8cf88832aa4b94f56542ed5b0