### PR TITLE
Mask IPs and tidy test records

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+from datetime import datetime
 
 from fastapi import FastAPI, Depends, Request
 from fastapi.middleware.cors import CORSMiddleware
@@ -15,6 +16,23 @@ models.Base.metadata.create_all(bind=database.engine)
 app = FastAPI()
 
 templates = Jinja2Templates(directory=str(Path(__file__).resolve().parent / "templates"))
+
+
+def mask_ip(ip: str) -> str:
+    parts = ip.split(".")
+    if len(parts) == 4:
+        return f"{parts[0]}.***.***.{parts[3]}"
+    return ip
+
+
+def short_ts(ts):
+    if isinstance(ts, datetime):
+        return ts.strftime("%Y-%m-%d %H:%M:%S")
+    return ts
+
+
+templates.env.filters["mask_ip"] = mask_ip
+templates.env.filters["short_ts"] = short_ts
 
 # Allow the frontend dev server or any origin to access the API
 app.add_middleware(

--- a/backend/templates/index.html
+++ b/backend/templates/index.html
@@ -27,17 +27,17 @@
   <body>
     <h1>Your Connection Info</h1>
     <ul>
-      <li>IP: {{ info.client_ip }}</li>
+      <li>IP: {{ info.client_ip|mask_ip }}</li>
       {% if info.location %}<li>Location: {{ info.location }}</li>{% endif %}
       {% if info.asn %}<li>ASN: {{ info.asn }}</li>{% endif %}
       {% if info.isp %}<li>ISP: {{ info.isp }}</li>{% endif %}
-      <li>Recorded at: {{ info.timestamp }}</li>
+      <li>Recorded at: {{ info.timestamp|short_ts }}</li>
     </ul>
 
     <h2>Recent Tests</h2>
     <ul>
       {% for r in records %}
-      <li>{{ r.client_ip }} - {{ r.location or 'Unknown' }} - {{ r.timestamp }}</li>
+      <li>{{ r.client_ip|mask_ip }}{% if r.location %} - {{ r.location }}{% endif %} - {{ r.timestamp|short_ts }}</li>
       {% endfor %}
     </ul>
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -18,6 +18,15 @@ interface TestsResponse {
   records: TestRecord[];
 }
 
+function maskIp(ip?: string | null) {
+  if (!ip) return '';
+  const parts = ip.split('.');
+  if (parts.length === 4) {
+    return `${parts[0]}.***.***.${parts[3]}`;
+  }
+  return ip;
+}
+
 function App() {
   const [info, setInfo] = useState<TestRecord | null>(null);
   const [records, setRecords] = useState<TestRecord[]>([]);
@@ -75,8 +84,10 @@ function App() {
         {info ? (
           <div className="space-y-2 text-center">
             <h1 className="text-xl mb-4">Your Connection Info</h1>
-            <div>IP: {info.client_ip}</div>
-            {info.location && <div>Location: {info.location}</div>}
+            <div>IP: {maskIp(info.client_ip)}</div>
+            {info.location && info.location !== 'Unknown' && (
+              <div>Location: {info.location}</div>
+            )}
             {info.asn && <div>ASN: {info.asn}</div>}
             {info.isp && <div>ISP: {info.isp}</div>}
             <div className="text-sm text-gray-400">
@@ -96,7 +107,8 @@ function App() {
                 .reverse()
                 .map((r) => (
                   <li key={r.id}>
-                    {r.client_ip} - {r.location} -{' '}
+                    {maskIp(r.client_ip)}
+                    {r.location && r.location !== 'Unknown' && ` - ${r.location}`} -{' '}
                     {new Date(r.timestamp).toLocaleString()}
                   </li>
                 ))}


### PR DESCRIPTION
## Summary
- obfuscate IP addresses and remove Unknown locations in recent tests
- shorten timestamps to second precision
- mask IPs and hide Unknown locations on the React frontend

## Testing
- `pytest`
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68941c3e2d44832a8fa2662f5e245adb