### PR TITLE
Add ping latency measurements

### DIFF
--- a/backend/templates/index.html
+++ b/backend/templates/index.html
@@ -31,13 +31,14 @@
       {% if info.location %}<li>Location: {{ info.location }}</li>{% endif %}
       {% if info.asn %}<li>ASN: {{ info.asn }}</li>{% endif %}
       {% if info.isp %}<li>ISP: {{ info.isp }}</li>{% endif %}
+      {% if info.ping_ms %}<li>Ping: {{ '%.2f'|format(info.ping_ms) }} ms</li>{% endif %}
       <li>Recorded at: {{ info.timestamp|short_ts }}</li>
     </ul>
 
     <h2>Recent Tests</h2>
     <ul>
       {% for r in records %}
-      <li>{{ r.client_ip|mask_ip }}{% if r.location %} - {{ r.location }}{% endif %} - {{ r.timestamp|short_ts }}</li>
+      <li>{{ r.client_ip|mask_ip }}{% if r.location %} - {{ r.location }}{% endif %}{% if r.ping_ms %} - {{ '%.2f'|format(r.ping_ms) }} ms{% endif %} - {{ r.timestamp|short_ts }}</li>
       {% endfor %}
     </ul>
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -90,6 +90,9 @@ function App() {
             )}
             {info.asn && <div>ASN: {info.asn}</div>}
             {info.isp && <div>ISP: {info.isp}</div>}
+            {typeof info.ping_ms === 'number' && (
+              <div>Ping: {info.ping_ms.toFixed(2)} ms</div>
+            )}
             <div className="text-sm text-gray-400">
               Recorded at: {new Date(info.timestamp).toLocaleString()}
             </div>
@@ -109,6 +112,7 @@ function App() {
                   <li key={r.id}>
                     {maskIp(r.client_ip)}
                     {r.location && r.location !== 'Unknown' && ` - ${r.location}`} -{' '}
+                    {typeof r.ping_ms === 'number' && `${r.ping_ms.toFixed(2)} ms - `}
                     {new Date(r.timestamp).toLocaleString()}
                   </li>
                 ))}


### PR DESCRIPTION
## Summary
- record ping latency for each test via `_ping` helper
- show measured latency on HTML template and React frontend

## Testing
- `python -m pytest`
- `cd frontend && npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68943669e33c832a9dc7cd44627798b5