### PR TITLE
Use venv for pip in Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,11 @@ RUN npm run build
 # Stage 2: build backend
 FROM python:3.11-slim
 WORKDIR /app
+
+# Use a virtual environment to avoid running pip as root
+RUN python -m venv /venv
+ENV PATH="/venv/bin:$PATH"
+
 COPY backend/requirements.txt ./backend/requirements.txt
 RUN apt-get update && apt-get install -y --no-install-recommends iputils-ping traceroute \
     && rm -rf /var/lib/apt/lists/* \


### PR DESCRIPTION
## Summary
- avoid pip root warning by using a virtual environment in Dockerfile

## Testing
- `pytest` *(fails: test_traceroute_endpoint_download)*

------
https://chatgpt.com/codex/tasks/task_e_68943c7787d8832a8cfec244e27f4da3