### PR TITLE
Fix mask_ip filter handling of null client IPs

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -34,7 +34,18 @@ app.add_middleware(SessionMiddleware, secret_key=os.environ.get("SESSION_SECRET"
 templates = Jinja2Templates(directory=str(Path(__file__).resolve().parent / "templates"))
 
 
-def mask_ip(ip: str) -> str:
+def mask_ip(ip: str | None) -> str | None:
+    """Partially mask an IPv4 address, gracefully handling ``None`` values.
+
+    The previous implementation assumed ``ip`` was always a string which caused
+    ``AttributeError`` when ``None`` was passed (e.g. when a test record had a
+    null ``client_ip``).  This version returns the input unchanged if it is
+    falsy and only performs masking for valid dotted IPv4 strings.
+    """
+
+    if not ip:
+        return ip
+
     parts = ip.split(".")
     if len(parts) == 4:
         return f"{parts[0]}.***.***.{parts[3]}"

--- a/backend/test_main.py
+++ b/backend/test_main.py
@@ -15,6 +15,26 @@ def test_homepage_creates_record_and_returns_html():
     assert data.get("records")
 
 
+def test_homepage_handles_null_client_ip():
+    """Ensure homepage renders even if a test record has a NULL client_ip."""
+    from backend.database import SessionLocal
+    from backend.models import TestRecord
+
+    db = SessionLocal()
+    try:
+        record = TestRecord(client_ip=None)
+        db.add(record)
+        db.commit()
+
+        res = client.get("/")
+        assert res.status_code == 200
+    finally:
+        # Clean up the record to avoid side effects between tests
+        db.delete(record)
+        db.commit()
+        db.close()
+
+
 def test_ping_endpoint_localhost():
     res = client.get("/ping", params={"host": "127.0.0.1", "count": 1})
     data = res.json()


### PR DESCRIPTION
## Summary
- handle `None` values in `mask_ip` filter to avoid homepage crash when records lack client IPs
- add regression test ensuring homepage renders with null `client_ip`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68943d2ba86c832a8681c89f787a583c