### PR TITLE
Aggregate recent tests and show speed metrics

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from datetime import datetime
+from datetime import datetime, timedelta
 import re
 import os
 import secrets
@@ -25,6 +25,7 @@ from fastapi.responses import (
 )
 from fastapi.templating import Jinja2Templates
 from sqlalchemy.orm import Session
+from sqlalchemy import func
 import requests
 import subprocess
 import tempfile
@@ -302,23 +303,39 @@ def api_root():
 
 @app.get("/tests", response_model=schemas.TestsResponse)
 def read_tests(request: Request, db: Session = Depends(get_db)):
-    """Return all stored test records.
+    """Return aggregated test records for the last ten minutes.
 
-    When the database is empty a default record is created automatically so
-    that the endpoint always returns at least one item without requiring a
-    manual ``POST`` from the user.
+    Multiple tests from the same ``client_ip`` within the last ten minutes are
+    collapsed into a single entry with average ``ping_ms``,
+    ``download_mbps`` and ``upload_mbps`` values computed directly in the
+    database.  The most recent ``timestamp`` for each IP is retained so that
+    results remain chronologically ordered.
     """
 
-    records = db.query(models.TestRecord).all()
-    if not records:
-        default_record = models.TestRecord(
-            client_ip=request.client.host,
-            test_target="default",
+    ten_min_ago = datetime.utcnow() - timedelta(minutes=10)
+    q = (
+        db.query(
+            func.max(models.TestRecord.id).label("id"),
+            models.TestRecord.client_ip,
+            func.max(models.TestRecord.location).label("location"),
+            func.max(models.TestRecord.asn).label("asn"),
+            func.max(models.TestRecord.isp).label("isp"),
+            func.avg(models.TestRecord.ping_ms).label("ping_ms"),
+            func.avg(models.TestRecord.download_mbps).label("download_mbps"),
+            func.avg(models.TestRecord.upload_mbps).label("upload_mbps"),
+            func.max(models.TestRecord.timestamp).label("timestamp"),
+            func.max(models.TestRecord.test_target).label("test_target"),
         )
-        db.add(default_record)
-        db.commit()
-        db.refresh(default_record)
-        records = [default_record]
+        .filter(models.TestRecord.timestamp >= ten_min_ago)
+        .group_by(models.TestRecord.client_ip)
+        .order_by(func.max(models.TestRecord.timestamp).desc())
+    )
+
+    rows = q.all()
+    if not rows:
+        return {"message": "No recent test records found", "records": []}
+
+    records = [schemas.TestRecord.model_validate(dict(row._mapping)) for row in rows]
     return {"records": records}
 
 

--- a/backend/test_main.py
+++ b/backend/test_main.py
@@ -101,3 +101,59 @@ def test_create_speedtest_record():
     assert data["speedtest_type"] == "single"
     assert data["download_mbps"] == 10.0
 
+
+def test_recent_tests_are_aggregated_by_ip():
+    from datetime import datetime, timedelta
+    from backend.database import SessionLocal
+    from backend.models import TestRecord
+
+    db = SessionLocal()
+    try:
+        db.query(TestRecord).delete()
+        now = datetime.utcnow()
+        records = [
+            TestRecord(
+                client_ip="1.1.1.1",
+                ping_ms=10,
+                download_mbps=20,
+                upload_mbps=5,
+                timestamp=now - timedelta(minutes=5),
+            ),
+            TestRecord(
+                client_ip="1.1.1.1",
+                ping_ms=20,
+                download_mbps=30,
+                upload_mbps=15,
+                timestamp=now - timedelta(minutes=4),
+            ),
+            TestRecord(
+                client_ip="2.2.2.2",
+                ping_ms=50,
+                download_mbps=60,
+                upload_mbps=70,
+                timestamp=now - timedelta(minutes=6),
+            ),
+            # Outside the 10 minute window and should be ignored
+            TestRecord(
+                client_ip="1.1.1.1",
+                ping_ms=30,
+                download_mbps=40,
+                upload_mbps=25,
+                timestamp=now - timedelta(minutes=15),
+            ),
+        ]
+        db.add_all(records)
+        db.commit()
+    finally:
+        db.close()
+
+    res = client.get("/tests")
+    assert res.status_code == 200
+    data = res.json()
+    assert len(data["records"]) == 2
+
+    rec = next(r for r in data["records"] if r["client_ip"] == "1.1.1.1")
+    assert abs(rec["ping_ms"] - 15) < 0.01
+    assert abs(rec["download_mbps"] - 25) < 0.01
+    assert abs(rec["upload_mbps"] - 10) < 0.01
+

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -8,6 +8,8 @@ interface TestRecord {
   asn?: string | null;
   isp?: string | null;
   ping_ms?: number | null;
+  download_mbps?: number | null;
+  upload_mbps?: number | null;
   mtr_result?: string | null;
   iperf_result?: string | null;
   test_target?: string | null;
@@ -117,13 +119,14 @@ function App() {
                     <th className="px-2 py-1 text-left">ASN</th>
                     <th className="px-2 py-1 text-left">ISP</th>
                     <th className="px-2 py-1 text-left">Ping</th>
+                    <th className="px-2 py-1 text-left">Download</th>
+                    <th className="px-2 py-1 text-left">Upload</th>
                     <th className="px-2 py-1 text-left">Recorded</th>
                   </tr>
                 </thead>
                 <tbody>
                   {records
-                    .slice(-5)
-                    .reverse()
+                    .slice(0, 5)
                     .map((r) => (
                       <tr key={r.id}>
                         <td className="px-2 py-1">{maskIp(r.client_ip)}</td>
@@ -134,6 +137,16 @@ function App() {
                         <td className="px-2 py-1">{r.isp || ''}</td>
                         <td className="px-2 py-1">
                           {typeof r.ping_ms === 'number' ? `${r.ping_ms.toFixed(2)} ms` : ''}
+                        </td>
+                        <td className="px-2 py-1">
+                          {typeof r.download_mbps === 'number'
+                            ? `${r.download_mbps.toFixed(2)} Mbps`
+                            : ''}
+                        </td>
+                        <td className="px-2 py-1">
+                          {typeof r.upload_mbps === 'number'
+                            ? `${r.upload_mbps.toFixed(2)} Mbps`
+                            : ''}
                         </td>
                         <td className="px-2 py-1">
                           {new Date(r.timestamp).toLocaleString()}


### PR DESCRIPTION
## Summary
- Aggregate test records by IP within the last 10 minutes and compute average ping, download, and upload speeds in the database
- Show download and upload speeds in the Recent Tests table
- Add test coverage for recent test aggregation

## Testing
- `pytest -q`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689447eb3270832ab65adf4e4cc9885a