### PR TITLE
Localize test record timestamps to Asia/Shanghai

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from datetime import datetime
+from datetime import datetime, timezone
 import re
 import os
 import secrets
@@ -7,6 +7,7 @@ import hashlib
 import hmac
 import logging
 import socket
+from zoneinfo import ZoneInfo
 
 from fastapi import (
     FastAPI,
@@ -62,8 +63,15 @@ def mask_ip(ip: str | None) -> str | None:
     return ip
 
 
+def to_shanghai(ts: datetime) -> datetime:
+    if ts.tzinfo is None:
+        ts = ts.replace(tzinfo=timezone.utc)
+    return ts.astimezone(ZoneInfo("Asia/Shanghai"))
+
+
 def short_ts(ts):
     if isinstance(ts, datetime):
+        ts = to_shanghai(ts)
         return ts.strftime("%Y-%m-%d %H:%M:%S")
     return ts
 

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -1,5 +1,6 @@
-from datetime import datetime
-from pydantic import BaseModel
+from datetime import datetime, timezone
+from zoneinfo import ZoneInfo
+from pydantic import BaseModel, field_serializer
 
 
 class TestRecordBase(BaseModel):
@@ -27,6 +28,12 @@ class TestRecordUpdate(TestRecordBase):
 class TestRecord(TestRecordBase):
     id: int
     timestamp: datetime
+
+    @field_serializer("timestamp")
+    def serialize_timestamp(self, dt: datetime, _info):
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=timezone.utc)
+        return dt.astimezone(ZoneInfo("Asia/Shanghai"))
 
     class Config:
         from_attributes = True


### PR DESCRIPTION
## Summary
- convert displayed timestamps to Asia/Shanghai using `to_shanghai` helper and Jinja filter
- serialize API timestamps with Asia/Shanghai timezone via Pydantic field serializer

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68944898b494832aa2ac131ce34338bb