### PR TITLE
chore: streamline ascii logo and add subtitle

### DIFF
--- a/backend/templates/index.html
+++ b/backend/templates/index.html
@@ -42,8 +42,8 @@ __   ___ __  ___ | |_ _____      ___ __
 | '_ \ / _ \ / _` |/ _ \ '_ \| '__/ _ \| '_ \ / _ \
 | | | | (_) | (_| |  __/ |_) | | | (_) | |_) |  __/
 |_| |_|\___/ \__,_|\___| .__/|_|  \___/|_.__/ \___|
-                       |_|
     </pre>
+    <div style="text-align: center;">Lightweight self-hosted probe service for global connectivity.</div>
     <h1>Your Connection Info</h1>
     <ul>
       <li>IP: {{ info.client_ip|mask_ip }}</li>


### PR DESCRIPTION
## Summary
- simplify homepage ASCII logo to a single block
- add a centered subtitle describing the service

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68945480f4ec832aba634398dafd5061