### PR TITLE
refactor: add dashboard route and dynamic tests table

### DIFF
--- a/backend/templates/index.html
+++ b/backend/templates/index.html
@@ -42,8 +42,8 @@ __   ___ __  ___ | |_ _____      ___ __
 | '_ \ / _ \ / _` |/ _ \ '_ \| '__/ _ \| '_ \ / _ \
 | | | | (_) | (_| |  __/ |_) | | | (_) | |_) |  __/
 |_| |_|\___/ \__,_|\___| .__/|_|  \___/|_.__/ \___|
-                       |_|
     </pre>
+    <div style="text-align: center;">Lightweight self-hosted probe service for global connectivity.</div>
     <h1>Your Connection Info</h1>
     <ul>
       <li>IP: {{ info.client_ip|mask_ip }}</li>
@@ -56,28 +56,19 @@ __   ___ __  ___ | |_ _____      ___ __
 
     <h2>Recent Tests</h2>
     <table>
-      <tr>
-        <th>IP</th>
-        <th>Location</th>
-        <th>ASN</th>
-        <th>ISP</th>
-        <th>Ping (min/avg/max)</th>
-        <th>Recorded</th>
-      </tr>
-      {% for r in records %}
-      <tr>
-        <td>{{ r.client_ip|mask_ip }}</td>
-        <td>{{ r.location or '' }}</td>
-        <td>{{ r.asn or '' }}</td>
-        <td>{{ r.isp or '' }}</td>
-        <td>
-          {% if r.ping_ms %}
-            {{ '%.2f'|format(r.ping_min_ms or r.ping_ms) }}/{{ '%.2f'|format(r.ping_ms) }}/{{ '%.2f'|format(r.ping_max_ms or r.ping_ms) }} ms
-          {% endif %}
-        </td>
-        <td>{{ r.timestamp|short_ts }}</td>
-      </tr>
-      {% endfor %}
+      <thead>
+        <tr>
+          <th>IP</th>
+          <th>Location</th>
+          <th>ASN</th>
+          <th>ISP</th>
+          <th>Ping (min/avg/max)</th>
+          <th>Download (Mbps)</th>
+          <th>Upload (Mbps)</th>
+          <th>Recorded</th>
+        </tr>
+      </thead>
+      <tbody id="records-body"></tbody>
     </table>
 
     <h2>Manual Ping Test</h2>
@@ -104,6 +95,45 @@ __   ___ __  ___ | |_ _____      ___ __
     <pre id="speed-output"></pre>
 
     <script>
+      async function loadRecentTests() {
+        const res = await fetch('/tests');
+        const data = await res.json();
+        const tbody = document.getElementById('records-body');
+        tbody.innerHTML = '';
+        (data.records || []).forEach(r => {
+          const tr = document.createElement('tr');
+          const cells = [
+            maskIp(r.client_ip),
+            r.location || '',
+            r.asn || '',
+            r.isp || '',
+            r.ping_ms ? `${((r.ping_min_ms ?? r.ping_ms)).toFixed(2)}/${(r.ping_ms).toFixed(2)}/${((r.ping_max_ms ?? r.ping_ms)).toFixed(2)} ms` : '',
+            r.download_mbps ? r.download_mbps.toFixed(2) : '',
+            r.upload_mbps ? r.upload_mbps.toFixed(2) : '',
+            formatTimestamp(r.timestamp)
+          ];
+          cells.forEach(text => {
+            const td = document.createElement('td');
+            td.textContent = text;
+            tr.appendChild(td);
+          });
+          tbody.appendChild(tr);
+        });
+      }
+
+      function maskIp(ip) {
+        if (!ip) return '';
+        const parts = ip.split('.');
+        return parts.length === 4 ? `${parts[0]}.***.***.${parts[3]}` : ip;
+      }
+
+      function formatTimestamp(ts) {
+        const d = new Date(ts);
+        return d.toLocaleString('zh-CN', { hour12: false });
+      }
+
+      window.addEventListener('load', loadRecentTests);
+
       async function runPing() {
         const host = document.getElementById('host').value;
         const res = await fetch('/ping?host=' + encodeURIComponent(host));
@@ -120,6 +150,7 @@ __   ___ __  ___ | |_ _____      ___ __
               ping_max_ms: data.ping_max_ms
             })
           });
+          loadRecentTests();
         }
       }
 
@@ -213,6 +244,7 @@ __   ___ __  ___ | |_ _____      ___ __
           `Single Thread - Download: ${single.down} Mbps Upload: ${single.up} Mbps\n` +
           `Multi Thread (${multiThreads}) - Download: ${multi.down} Mbps Upload: ${multi.up} Mbps`;
         document.getElementById('download-speed').textContent = `- ${multi.down} Mbps`;
+        loadRecentTests();
       }
     </script>
   </body>

--- a/backend/test_main.py
+++ b/backend/test_main.py
@@ -6,7 +6,7 @@ client = TestClient(app)
 
 
 def test_homepage_creates_record_and_returns_html():
-    res = client.get("/")
+    res = client.get("/probe")
     assert res.status_code == 200
     assert "Your Connection Info" in res.text
 
@@ -26,7 +26,7 @@ def test_homepage_handles_null_client_ip():
         db.add(record)
         db.commit()
 
-        res = client.get("/")
+        res = client.get("/probe")
         assert res.status_code == 200
     finally:
         # Clean up the record to avoid side effects between tests


### PR DESCRIPTION
## Summary
- redirect root to a new `/probe` dashboard
- load recent tests asynchronously with 10-minute aggregation and speedtest metrics

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68945480f4ec832aba634398dafd5061