### PR TITLE
Aggregate recent tests and show speed metrics

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from datetime import datetime
+from datetime import datetime, timedelta
 import re
 import os
 import secrets
@@ -25,6 +25,7 @@ from fastapi.responses import (
 )
 from fastapi.templating import Jinja2Templates
 from sqlalchemy.orm import Session
+from sqlalchemy import func
 import requests
 import subprocess
 import tempfile
@@ -302,23 +303,39 @@ def api_root():
 
 @app.get("/tests", response_model=schemas.TestsResponse)
 def read_tests(request: Request, db: Session = Depends(get_db)):
-    """Return all stored test records.
+    """Return aggregated test records for the last ten minutes.
 
-    When the database is empty a default record is created automatically so
-    that the endpoint always returns at least one item without requiring a
-    manual ``POST`` from the user.
+    Multiple tests from the same ``client_ip`` within the last ten minutes are
+    collapsed into a single entry with average ``ping_ms``,
+    ``download_mbps`` and ``upload_mbps`` values computed directly in the
+    database.  The most recent ``timestamp`` for each IP is retained so that
+    results remain chronologically ordered.
     """
 
-    records = db.query(models.TestRecord).all()
-    if not records:
-        default_record = models.TestRecord(
-            client_ip=request.client.host,
-            test_target="default",
+    ten_min_ago = datetime.utcnow() - timedelta(minutes=10)
+    q = (
+        db.query(
+            func.max(models.TestRecord.id).label("id"),
+            models.TestRecord.client_ip,
+            func.max(models.TestRecord.location).label("location"),
+            func.max(models.TestRecord.asn).label("asn"),
+            func.max(models.TestRecord.isp).label("isp"),
+            func.avg(models.TestRecord.ping_ms).label("ping_ms"),
+            func.avg(models.TestRecord.download_mbps).label("download_mbps"),
+            func.avg(models.TestRecord.upload_mbps).label("upload_mbps"),
+            func.max(models.TestRecord.timestamp).label("timestamp"),
+            func.max(models.TestRecord.test_target).label("test_target"),
         )
-        db.add(default_record)
-        db.commit()
-        db.refresh(default_record)
-        records = [default_record]
+        .filter(models.TestRecord.timestamp >= ten_min_ago)
+        .group_by(models.TestRecord.client_ip)
+        .order_by(func.max(models.TestRecord.timestamp).desc())
+    )
+
+    rows = q.all()
+    if not rows:
+        return {"message": "No recent test records found", "records": []}
+
+    records = [schemas.TestRecord.model_validate(dict(row._mapping)) for row in rows]
     return {"records": records}
 
 

--- a/backend/test_main.py
+++ b/backend/test_main.py
@@ -101,3 +101,59 @@ def test_create_speedtest_record():
     assert data["speedtest_type"] == "single"
     assert data["download_mbps"] == 10.0
 
+
+def test_recent_tests_are_aggregated_by_ip():
+    from datetime import datetime, timedelta
+    from backend.database import SessionLocal
+    from backend.models import TestRecord
+
+    db = SessionLocal()
+    try:
+        db.query(TestRecord).delete()
+        now = datetime.utcnow()
+        records = [
+            TestRecord(
+                client_ip="1.1.1.1",
+                ping_ms=10,
+                download_mbps=20,
+                upload_mbps=5,
+                timestamp=now - timedelta(minutes=5),
+            ),
+            TestRecord(
+                client_ip="1.1.1.1",
+                ping_ms=20,
+                download_mbps=30,
+                upload_mbps=15,
+                timestamp=now - timedelta(minutes=4),
+            ),
+            TestRecord(
+                client_ip="2.2.2.2",
+                ping_ms=50,
+                download_mbps=60,
+                upload_mbps=70,
+                timestamp=now - timedelta(minutes=6),
+            ),
+            # Outside the 10 minute window and should be ignored
+            TestRecord(
+                client_ip="1.1.1.1",
+                ping_ms=30,
+                download_mbps=40,
+                upload_mbps=25,
+                timestamp=now - timedelta(minutes=15),
+            ),
+        ]
+        db.add_all(records)
+        db.commit()
+    finally:
+        db.close()
+
+    res = client.get("/tests")
+    assert res.status_code == 200
+    data = res.json()
+    assert len(data["records"]) == 2
+
+    rec = next(r for r in data["records"] if r["client_ip"] == "1.1.1.1")
+    assert abs(rec["ping_ms"] - 15) < 0.01
+    assert abs(rec["download_mbps"] - 25) < 0.01
+    assert abs(rec["upload_mbps"] - 10) < 0.01
+

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -8,6 +8,8 @@ interface TestRecord {
   asn?: string | null;
   isp?: string | null;
   ping_ms?: number | null;
+  download_mbps?: number | null;
+  upload_mbps?: number | null;
   mtr_result?: string | null;
   iperf_result?: string | null;
   test_target?: string | null;
@@ -33,10 +35,32 @@ function App() {
   const [recordsMessage, setRecordsMessage] = useState<string | null>(null);
   const [pingTarget, setPingTarget] = useState('8.8.8.8');
   const [pingOutput, setPingOutput] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  const loadRecords = async () => {
+    try {
+      const res = await fetch('/tests');
+      const data: TestsResponse = await res.json();
+      const filtered = (data.records || []).filter(
+        (r) =>
+          r.client_ip &&
+          (typeof r.ping_ms === 'number' ||
+            typeof r.download_mbps === 'number' ||
+            typeof r.upload_mbps === 'number')
+      );
+      setRecords(filtered);
+      if (data.message) {
+        setRecordsMessage(data.message);
+      }
+    } catch (err) {
+      console.error('Failed to load previous tests', err);
+    }
+  };
 
   useEffect(() => {
-    const collect = async () => {
+    const runTests = async () => {
       try {
+        // Create an initial record and gather client info + ping.
         const res = await fetch('/tests', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
@@ -46,27 +70,75 @@ function App() {
         setInfo(data);
         if (data.client_ip) {
           setPingTarget(data.client_ip);
+          try {
+            // Run traceroute but ignore the result for now.
+            await fetch(`/traceroute?host=${encodeURIComponent(data.client_ip)}`);
+          } catch (err) {
+            console.error('Traceroute failed', err);
+          }
         }
+
+        try {
+          // Run a basic speed test (multi-thread download/upload).
+          const downloadSize = 5 * 1024 * 1024; // 5 MB
+          const uploadSize = 2 * 1024 * 1024; // 2 MB
+          const chunkSize = downloadSize / 4;
+
+          const downloadSpeed = async () => {
+            const start = performance.now();
+            await Promise.all(
+              Array.from({ length: 4 }, () =>
+                fetch(`/speedtest/download?size=${chunkSize}`).then((r) => r.arrayBuffer())
+              )
+            );
+            const end = performance.now();
+            return ((downloadSize * 8) / (end - start) / 1000).toFixed(2);
+          };
+
+          const uploadSpeed = () =>
+            new Promise<string>((resolve) => {
+              let completed = 0;
+              const start = performance.now();
+              const part = uploadSize / 4;
+              for (let i = 0; i < 4; i++) {
+                const xhr = new XMLHttpRequest();
+                xhr.open('POST', '/speedtest/upload');
+                xhr.onload = () => {
+                  completed++;
+                  if (completed === 4) {
+                    const end = performance.now();
+                    resolve(((uploadSize * 8) / (end - start) / 1000).toFixed(2));
+                  }
+                };
+                xhr.send(new Uint8Array(part));
+              }
+            });
+
+          const down = await downloadSpeed();
+          const up = await uploadSpeed();
+          await fetch('/tests', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+              test_target: 'speedtest',
+              speedtest_type: 'auto',
+              download_mbps: parseFloat(down),
+              upload_mbps: parseFloat(up),
+            }),
+          });
+        } catch (err) {
+          console.error('Speedtest failed', err);
+        }
+
+        await loadRecords();
       } catch (err) {
-        console.error('Failed to collect info', err);
+        console.error('Automatic tests failed', err);
+      } finally {
+        setLoading(false);
       }
     };
 
-    const loadRecords = async () => {
-      try {
-        const res = await fetch('/tests');
-        const data: TestsResponse = await res.json();
-        setRecords(data.records || []);
-        if (data.message) {
-          setRecordsMessage(data.message);
-        }
-      } catch (err) {
-        console.error('Failed to load previous tests', err);
-      }
-    };
-
-    collect();
-    setTimeout(loadRecords, 0);
+    runTests();
   }, []);
 
   const runPing = async () => {
@@ -81,6 +153,13 @@ function App() {
       setPingOutput('Ping failed');
     }
   };
+  if (loading) {
+    return (
+      <div className="min-h-screen bg-gradient-to-br from-black via-purple-900 to-indigo-900 text-green-400 flex items-center justify-center p-4">
+        <div>Running tests...</div>
+      </div>
+    );
+  }
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-black via-purple-900 to-indigo-900 text-green-400 flex items-center justify-center p-4">
@@ -102,7 +181,7 @@ function App() {
             </div>
           </div>
         ) : (
-          <div>Loading...</div>
+          <div>No info available</div>
         )}
 
         <div className="space-y-2">
@@ -117,13 +196,14 @@ function App() {
                     <th className="px-2 py-1 text-left">ASN</th>
                     <th className="px-2 py-1 text-left">ISP</th>
                     <th className="px-2 py-1 text-left">Ping</th>
+                    <th className="px-2 py-1 text-left">Download</th>
+                    <th className="px-2 py-1 text-left">Upload</th>
                     <th className="px-2 py-1 text-left">Recorded</th>
                   </tr>
                 </thead>
                 <tbody>
                   {records
-                    .slice(-5)
-                    .reverse()
+                    .slice(0, 5)
                     .map((r) => (
                       <tr key={r.id}>
                         <td className="px-2 py-1">{maskIp(r.client_ip)}</td>
@@ -134,6 +214,16 @@ function App() {
                         <td className="px-2 py-1">{r.isp || ''}</td>
                         <td className="px-2 py-1">
                           {typeof r.ping_ms === 'number' ? `${r.ping_ms.toFixed(2)} ms` : ''}
+                        </td>
+                        <td className="px-2 py-1">
+                          {typeof r.download_mbps === 'number'
+                            ? `${r.download_mbps.toFixed(2)} Mbps`
+                            : ''}
+                        </td>
+                        <td className="px-2 py-1">
+                          {typeof r.upload_mbps === 'number'
+                            ? `${r.upload_mbps.toFixed(2)} Mbps`
+                            : ''}
                         </td>
                         <td className="px-2 py-1">
                           {new Date(r.timestamp).toLocaleString()}


### PR DESCRIPTION
## Summary
- Run ping, traceroute, and a multi-threaded speed test automatically on page load, displaying a loading screen until finished
- Filter out records lacking metrics so the Recent Tests table no longer shows empty rows

## Testing
- `pytest -q`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689447eb3270832ab65adf4e4cc9885a