### PR TITLE
Add real-time traffic window to speed test

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -157,10 +157,12 @@ function App() {
   const [speedResult, setSpeedResult] = useState<{ down: number; up: number } | null>(
     null,
   );
-    const [downloadSpeeds, setDownloadSpeeds] = useState<number[]>([]);
-    const [uploadSpeeds, setUploadSpeeds] = useState<number[]>([]);
-    const [speedRunning, setSpeedRunning] = useState(false);
-    const [loadingMsg, setLoadingMsg] = useState('');
+  const [downloadSpeeds, setDownloadSpeeds] = useState<number[]>([]);
+  const [uploadSpeeds, setUploadSpeeds] = useState<number[]>([]);
+  const [currentDownloadSpeed, setCurrentDownloadSpeed] = useState(0);
+  const [currentUploadSpeed, setCurrentUploadSpeed] = useState(0);
+  const [speedRunning, setSpeedRunning] = useState(false);
+  const [loadingMsg, setLoadingMsg] = useState('');
 
     useEffect(() => {
       runInitialTests();
@@ -241,6 +243,7 @@ function App() {
   async function downloadWithProgress(size: number) {
     setDownloadProgress({ transferred: 0, size });
     setDownloadSpeeds([]);
+    setCurrentDownloadSpeed(0);
     const res = await fetch(`/speedtest/download?size=${size}`);
     const reader = res.body?.getReader();
     if (!reader) return 0;
@@ -256,6 +259,7 @@ function App() {
       const diff = now - lastTime;
       if (diff > 0 && value) {
         const speed = (value.length * 8) / diff / 1000;
+        setCurrentDownloadSpeed(speed);
         setDownloadSpeeds((s) => [...s.slice(-99), speed]);
       }
       lastTime = now;
@@ -267,6 +271,7 @@ function App() {
   function uploadWithProgress(size: number) {
     setUploadProgress({ transferred: 0, size });
     setUploadSpeeds([]);
+    setCurrentUploadSpeed(0);
     return new Promise<number>((resolve) => {
       const xhr = new XMLHttpRequest();
       const start = performance.now();
@@ -280,6 +285,7 @@ function App() {
         const loadedDiff = e.loaded - lastLoaded;
         if (diff > 0 && loadedDiff > 0) {
           const speed = (loadedDiff * 8) / diff / 1000;
+          setCurrentUploadSpeed(speed);
           setUploadSpeeds((s) => [...s.slice(-99), speed]);
         }
         lastTime = now;
@@ -298,6 +304,8 @@ function App() {
     setSpeedResult(null);
     setDownloadSpeeds([]);
     setUploadSpeeds([]);
+    setCurrentDownloadSpeed(0);
+    setCurrentUploadSpeed(0);
     const down = await downloadWithProgress(downloadSize);
     const up = await uploadWithProgress(uploadSize);
     setSpeedResult({ down, up });
@@ -313,6 +321,8 @@ function App() {
     });
     await loadRecords();
     setSpeedRunning(false);
+    setCurrentDownloadSpeed(0);
+    setCurrentUploadSpeed(0);
   };
   if (loading) {
     return (
@@ -461,6 +471,20 @@ function App() {
           </div>
           <div>Download Progress: {formatProgress(downloadProgress)}</div>
           <div>Upload Progress: {formatProgress(uploadProgress)}</div>
+          <div className="flex justify-center space-x-4">
+            <div className="bg-black bg-opacity-50 rounded p-2 w-40">
+              <div>Download</div>
+              <div className="text-lg">
+                {currentDownloadSpeed.toFixed(2)} Mbps
+              </div>
+            </div>
+            <div className="bg-black bg-opacity-50 rounded p-2 w-40">
+              <div>Upload</div>
+              <div className="text-lg">
+                {currentUploadSpeed.toFixed(2)} Mbps
+              </div>
+            </div>
+          </div>
           {downloadSpeeds.length > 0 && (
             <SpeedChart
               title="Download Speed (Mbps)"


### PR DESCRIPTION
## Summary
- track current download/upload speed during speed tests
- show real-time traffic window with current speeds while running tests

## Testing
- `npm test` (fails: Missing script)
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68946558f5dc832a986a20161a90d368