### PR TITLE
Log initial admin password to startup logs

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -102,14 +102,17 @@ def create_default_user():
             )
             db.add(user)
             db.commit()
-            logger.info(
-                "Initial admin credentials - username: NodeProbe password: %s",
-                password,
+            msg = (
+                "Initial admin credentials - username: NodeProbe password: %s"
+                % password
             )
-        logger.info(
-            "Login help: visit http://%s:8380/ to access the dashboard.",
-            host_ip,
+            logger.info(msg)
+            print(msg, flush=True)
+        log_msg = (
+            "Login help: visit http://%s:8380/ to access the dashboard." % host_ip
         )
+        logger.info(log_msg)
+        print(log_msg, flush=True)
     finally:
         db.close()
 


### PR DESCRIPTION
## Summary
- Print generated admin password and dashboard URL during startup so they appear in Docker logs

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689470ff8f18832a8ceed1538b4ba1e7