### PR TITLE
feat(frontend): add animated loading screen

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -4,24 +4,60 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Vite + React + TS</title>
+    <title>NodeProbe</title>
+    <style>
+      html, body, #root {
+        height: 100%;
+        margin: 0;
+      }
+      body {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        background: linear-gradient(to bottom right, #000000, #4c1d95, #1e1b4b);
+        color: #4ade80;
+      }
+      .loading {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        gap: 1rem;
+      }
+      .spinner {
+        width: 48px;
+        height: 48px;
+        border-radius: 50%;
+        border: 4px solid rgba(74, 222, 128, 0.3);
+        border-top-color: #4ade80;
+        animation: spin 1s linear infinite;
+      }
+      @keyframes spin {
+        to {
+          transform: rotate(360deg);
+        }
+      }
+      .loading-text {
+        font-size: 1rem;
+        animation: pulse 1.5s ease-in-out infinite;
+      }
+      @keyframes pulse {
+        0%, 100% {
+          opacity: 1;
+        }
+        50% {
+          opacity: 0.5;
+        }
+      }
+    </style>
   </head>
   <body>
-    <pre style="text-align: center;">
-                  _
-__   ___ __  ___ | |_ _____      ___ __
-\ \ / / '_ \/ __|| __/ _ \ \ /\ / / '_ \
- \ V /| |_) \__ \| || (_) \ V  V /| | | |
-  \_/ | .__/|___/|__\___/ \_/\_/ |_| |_|
-      |_|
-                 _                      _
- _ __   ___   __| | ___ _ __  _ __ ___ | |__   ___
-| '_ \ / _ \ / _` |/ _ \ '_ \| '__/ _ \| '_ \ / _ \
-| | | | (_) | (_| |  __/ |_) | | | (_) | |_) |  __/
-|_| |_|\___/ \__,_|\___| .__/|_|  \___/|_.__/ \___|
-                       |_|
-    </pre>
-    <div id="root"></div>
+    <div id="root">
+      <div class="loading">
+        <div class="spinner"></div>
+        <div class="loading-text">Loading...</div>
+      </div>
+    </div>
     <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -416,9 +416,10 @@ function App() {
   if (loading) {
     return (
       <div className="min-h-screen bg-gradient-to-br from-black via-purple-900 to-indigo-900 text-green-400 flex items-center justify-center p-4">
-        <div className="text-center space-y-2">
-          <div>Loading...</div>
-          {loadingMsg && <div>{loadingMsg}</div>}
+        <div className="flex flex-col items-center space-y-4">
+          <div className="w-12 h-12 border-4 border-green-400 border-t-transparent rounded-full animate-spin" />
+          <div className="text-lg animate-pulse">Loading...</div>
+          {loadingMsg && <div className="text-sm animate-pulse">{loadingMsg}</div>}
         </div>
       </div>
     );


### PR DESCRIPTION
## Summary
- restyle loading screen with gradient background and spinner
- add animated spinner and pulsing text for in-app loading state

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689475915044832ab05abed6ad7927c3