### PR TITLE
Display default admin password and prompt password change

### DIFF
--- a/backend/templates/admin.html
+++ b/backend/templates/admin.html
@@ -7,6 +7,10 @@
 <body>
     <h1>Test Records Admin</h1>
     <p><a href="/admin/logout">Logout</a></p>
+    {% if user.must_change_password %}
+    <p style="color:red;">You are using the default password. Please change it.</p>
+    <button onclick="location.href='/admin/password'">Change Password</button>
+    {% endif %}
     <section>
         <h2>Add / Edit Record</h2>
         <form id="recordForm">

--- a/backend/templates/login.html
+++ b/backend/templates/login.html
@@ -7,6 +7,9 @@
 <body>
     <h1>NodeProbe Admin Login</h1>
     {% if error %}<p style="color:red">{{ error }}</p>{% endif %}
+    {% if default_password %}
+    <p>Default Password: {{ default_password }}</p>
+    {% endif %}
     <form method="post">
         <label>Username: <input name="username" value="NodeProbe" /></label><br>
         <label>Password: <input type="password" name="password" /></label><br>

--- a/backend/test_main.py
+++ b/backend/test_main.py
@@ -98,7 +98,9 @@ def test_register_and_login_requires_password_change():
         follow_redirects=False,
     )
     assert res_login.status_code == 303
-    assert res_login.headers["location"] == "/admin/password"
+    assert res_login.headers["location"] == "/admin"
+    res_admin = client.get("/admin")
+    assert "Change Password" in res_admin.text
 
 def test_create_speedtest_record():
     payload = {


### PR DESCRIPTION
## Summary
- compute and expose default admin password when still active
- redirect to dashboard after login and show reminder to change default password

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6894766aed38832ab738fd40c65a5637