### PR TITLE
fix: update Node base image for deployment build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # Multi-stage build: build frontend and backend
 
 # Stage 1: build frontend
-FROM node:18 AS frontend-builder
+FROM node:20 AS frontend-builder
 WORKDIR /app/frontend
 COPY frontend/package*.json ./
 RUN npm ci


### PR DESCRIPTION
## Summary
- use Node 20 image in Dockerfile so frontend build works with Vite's crypto.hash

## Testing
- `pytest -q`
- `cd frontend && npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68947801d7c0832a90a021dc54facdb4