### PR TITLE
Ensure recent ping results reflect auto tests

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -434,7 +434,10 @@ def read_tests(request: Request, db: Session = Depends(get_db)):
 
 @app.post("/tests", response_model=schemas.TestRecord)
 def create_test(
-    record: schemas.TestRecordCreate, request: Request, db: Session = Depends(get_db)
+    record: schemas.TestRecordCreate,
+    request: Request,
+    db: Session = Depends(get_db),
+    skip_ping: bool = False,
 ):
     data = record.dict()
     client_ip = _get_client_ip(request)
@@ -453,14 +456,18 @@ def create_test(
         except Exception:
             pass
 
-    if not data.get("ping_ms"):
-        host = data.get("test_target") or client_ip
-        ping_ms = _ping(host)
-        if ping_ms is not None:
-            data["ping_ms"] = ping_ms
-            data.setdefault("ping_min_ms", ping_ms)
-            data.setdefault("ping_max_ms", ping_ms)
-    else:
+    if not skip_ping:
+        if not data.get("ping_ms"):
+            host = data.get("test_target") or client_ip
+            ping_ms = _ping(host)
+            if ping_ms is not None:
+                data["ping_ms"] = ping_ms
+                data.setdefault("ping_min_ms", ping_ms)
+                data.setdefault("ping_max_ms", ping_ms)
+        else:
+            data.setdefault("ping_min_ms", data["ping_ms"])
+            data.setdefault("ping_max_ms", data["ping_ms"])
+    elif data.get("ping_ms") is not None:
         data.setdefault("ping_min_ms", data["ping_ms"])
         data.setdefault("ping_max_ms", data["ping_ms"])
 

--- a/backend/test_main.py
+++ b/backend/test_main.py
@@ -55,6 +55,13 @@ def test_ping_endpoint_localhost():
     assert "ping_max_ms" in data
 
 
+def test_create_test_skip_ping():
+    res = client.post("/tests?skip_ping=true", json={})
+    assert res.status_code == 200
+    data = res.json()
+    assert data.get("ping_ms") is None
+
+
 def test_traceroute_endpoint_download():
     res = client.get("/traceroute", params={"host": "127.0.0.1", "download": "true"})
     assert res.status_code == 200

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -166,7 +166,7 @@ function App() {
     setLoading(true);
     setLoadingMsg('正在进行 ping Traceroute 测试...');
     try {
-      const res = await fetch('/tests', {
+      const res = await fetch('/tests?skip_ping=true', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: '{}',
@@ -205,6 +205,31 @@ function App() {
       const res = await fetch(`/ping?host=${encodeURIComponent(host)}&count=10`);
       const data = await res.json();
       setPingOutput(data.output || data.error || 'No output');
+      if (typeof data.ping_ms === 'number') {
+        try {
+          await fetch('/tests', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+              ping_ms: data.ping_ms,
+              ping_min_ms: data.ping_min_ms,
+              ping_max_ms: data.ping_max_ms,
+            }),
+          });
+        } catch (e) {
+          console.error('Failed to record ping result', e);
+        }
+        setInfo((prev) =>
+          prev
+            ? {
+                ...prev,
+                ping_ms: data.ping_ms,
+                ping_min_ms: data.ping_min_ms,
+                ping_max_ms: data.ping_max_ms,
+              }
+            : prev
+        );
+      }
     } catch (err) {
       console.error('Ping failed', err);
       setPingOutput('Ping failed');


### PR DESCRIPTION
## Summary
- allow skipping automatic ping in `/tests` by adding `skip_ping` query option
- record auto ping output to `/tests` and update frontend state
- cover `skip_ping` behavior with a new backend test

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68947c28676c832a9ebf171dec774cf4