### PR TITLE
fix: remove duplicate credential logs

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -116,16 +116,13 @@ def create_default_user():
                 % password
             )
             logger.info(msg)
-            print(msg, flush=True)
         else:
             logger.info("Admin user already exists; no default password generated.")
-            print("Admin user already exists; no default password generated.", flush=True)
 
         log_msg = (
             "Login help: visit http://%s:8380/ to access the dashboard." % host_ip
         )
         logger.info(log_msg)
-        print(log_msg, flush=True)
     finally:
         db.close()
 


### PR DESCRIPTION
## Summary
- avoid repeating default credential & login messages by removing print calls

## Testing
- `pytest -q | tail -n 2`

------
https://chatgpt.com/codex/tasks/task_e_68947f0ddbd8832a947d4c03029894b2