### PR TITLE
feat: add ASCII logo to loading and probe pages

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -49,6 +49,22 @@ function maskIp(ip?: string | null) {
   return ip;
 }
 
+const ASCII_LOGO = [
+  "__      _______   _____ _______ ______          ___   _",
+  "\\ \\    / /  __ \\ / ____|__   __/ __ \\ \\        / / \\ | |",
+  " \\ \\  / /| |__) | (___    | | | |  | \\ \\  /\\  / /|  \\| |",
+  "  \\ \\/ / |  ___/ \\___ \\   | | | |  | |\\ \\/  \\/ / | . ` |",
+  "   \\  /  | |     ____) |  | | | |__| | \\  /\\  /  | |\\  |",
+  "    \\/   |_|    |_____(_) |_|  \\____/   \\/  \\/   |_| \\_|",
+  "",
+  " _   _           _        _____           _",
+  "| \\ | |         | |      |  __ \\         | |",
+  "|  \\| | ___   __| | ___  | |__) | __ ___ | |__   ___",
+  "| . ` |/ _ \\ / _` |/ _ \\ |  ___/ '__/ _ \\| '_ \\ / _ \\",
+  "| |\\  | (_) | (_| |  __/ | |   | | | (_) | |_) |  __/",
+  "|_| \\_|\\___/ \\__,_|\\___| |_|   |_|  \\___/|_.__/ \\___|"
+].join('\n');
+
 function App() {
   const [info, setInfo] = useState<AggregatedRecord | null>(null);
   const [records, setRecords] = useState<AggregatedRecord[]>([]);
@@ -486,7 +502,7 @@ function App() {
     return (
       <div className="min-h-screen bg-gradient-to-br from-black via-green-900 to-black text-green-400 flex items-center justify-center p-4">
         <div className="flex flex-col items-center space-y-4">
-          <pre className="text-center whitespace-pre font-mono">VPS.TOWN   Node Probe</pre>
+          <pre className="text-center whitespace-pre font-mono">{ASCII_LOGO}</pre>
           <div className="w-12 h-12 border-4 border-green-400 border-t-transparent rounded-full animate-spin" />
           <div className="text-lg animate-pulse">Loading...</div>
           {loadingMsg && <div className="text-sm animate-pulse">{loadingMsg}</div>}
@@ -498,7 +514,7 @@ function App() {
   return (
     <div className="min-h-screen bg-gradient-to-br from-black via-green-900 to-black text-green-400 p-4">
       <div className="w-full max-w-3xl mx-auto space-y-8">
-        <pre className="text-center whitespace-pre font-mono">VPS.TOWN   Node Probe</pre>
+        <pre className="text-center whitespace-pre font-mono">{ASCII_LOGO}</pre>
         {info ? (
           <div className="space-y-2 text-center">
             <h1 className="text-xl mb-4">Your Connection Info</h1>


### PR DESCRIPTION
## Summary
- display ASCII art logo for VPS.TOWN Node Probe on loading page
- show same ASCII art at top of probe page for consistent branding

## Testing
- `npm run lint`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68947f639bf4832abc8a40ca469a7333