### PR TITLE
feat: run speedtest after loading

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -156,6 +156,7 @@ function App() {
   const [currentUploadSpeed, setCurrentUploadSpeed] = useState(0);
   const [speedRunning, setSpeedRunning] = useState(false);
   const [loadingMsg, setLoadingMsg] = useState('');
+  const [autoSpeedtestDone, setAutoSpeedtestDone] = useState(false);
 
   const downloadControllers = useRef<AbortController[]>([]);
   const uploadXhrs = useRef<XMLHttpRequest[]>([]);
@@ -189,9 +190,6 @@ function App() {
       if (data?.client_ip) {
         await runPing(data.client_ip);
         await runTraceroute(data.client_ip, true);
-        setLoadingMsg('正在进行 Speedtest 测试...');
-        await runSpeedtest(100 * 1024 * 1024, 50 * 1024 * 1024, 1);
-        await runSpeedtest(100 * 1024 * 1024, 50 * 1024 * 1024, 8);
       }
     } catch (err) {
       console.error('Failed to run initial tests', err);
@@ -468,6 +466,16 @@ function App() {
       setCurrentUploadSpeed(0);
     }
   };
+
+  useEffect(() => {
+    if (!loading && info && !autoSpeedtestDone) {
+      setAutoSpeedtestDone(true);
+      (async () => {
+        await runSpeedtest(100 * 1024 * 1024, 50 * 1024 * 1024, 8);
+        await runSpeedtest(100 * 1024 * 1024, 50 * 1024 * 1024, 1);
+      })();
+    }
+  }, [loading, info, autoSpeedtestDone]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const stopSpeedtest = () => {
     downloadControllers.current.forEach((c) => c.abort());


### PR DESCRIPTION
## Summary
- skip speed tests during initial loading
- auto run 8-thread and single-thread 100M speed tests once probe screen loads

## Testing
- `pytest`
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689480f4146c832a8cddf6e0eb1a6351