### PR TITLE
feat: enhance speed test visuals

### DIFF
--- a/frontend/src/SpeedChart.tsx
+++ b/frontend/src/SpeedChart.tsx
@@ -18,20 +18,30 @@ export default function SpeedChart({ title, speeds, color }: SpeedChartProps) {
   return (
     <div className="space-y-1">
       <div>{title}</div>
-      <svg
-        width={width}
-        height={height}
-        className="bg-black bg-opacity-50 rounded"
-      >
-        <polyline
-          points={points}
-          fill="none"
-          stroke={color}
-          strokeWidth={2}
-          strokeLinecap="round"
-          strokeLinejoin="round"
-        />
-      </svg>
+      <div className="flex items-center">
+        <svg
+          width={width}
+          height={height}
+          className="bg-black bg-opacity-50 rounded shadow-md"
+        >
+          <polyline
+            points={points}
+            fill="none"
+            stroke={color}
+            strokeWidth={2}
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            style={{ transition: 'all 1s ease' }}
+          />
+        </svg>
+        <div className="flex items-center ml-2 space-x-1 text-xs text-gray-300">
+          <span
+            className="w-3 h-3 rounded-full"
+            style={{ backgroundColor: color }}
+          />
+          <span>{title}</span>
+        </div>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- improve speed test chart styling and add legend
- smooth speed updates and refresh metrics once per second

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68948352b70c832ab0220231723adb01