### PR TITLE
Add pagination to admin test records

### DIFF
--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -57,5 +57,10 @@ class TestsResponse(BaseModel):
     records: list[TestRecord] = []
 
 
+class AdminTestsResponse(BaseModel):
+    total: int
+    records: list[TestRecord] = []
+
+
 class IDList(BaseModel):
     ids: list[int]

--- a/backend/templates/admin.html
+++ b/backend/templates/admin.html
@@ -45,71 +45,37 @@
                     <th>Ping Avg(ms)</th>
                     <th>Ping Min(ms)</th>
                     <th>Ping Max(ms)</th>
-                    <th>Single DL(Mbps)</th>
-                    <th>Single UL(Mbps)</th>
-                    <th>Multi DL(Mbps)</th>
-                    <th>Multi UL(Mbps)</th>
+                    <th>Download(Mbps)</th>
+                    <th>Upload(Mbps)</th>
+                    <th>Speedtest Type</th>
                     <th>Target</th>
                     <th>Actions</th>
                 </tr>
             </thead>
             <tbody></tbody>
         </table>
+        <div id="pagination">
+            <button id="prevPage">Prev</button>
+            <span id="pageInfo"></span>
+            <button id="nextPage">Next</button>
+        </div>
     </section>
 <script>
-async function loadRecords() {
-    const res = await fetch('/tests');
+const pageSize = 100;
+let currentPage = 1;
+let totalRecords = 0;
+let currentRecords = [];
+
+async function loadRecords(page = 1) {
+    const offset = (page - 1) * pageSize;
+    const res = await fetch(`/admin/tests?offset=${offset}&limit=${pageSize}`);
     const data = await res.json();
     const tbody = document.querySelector('#recordsTable tbody');
     tbody.innerHTML = '';
-    const map = new Map();
-    data.records.forEach(rec => {
-        if (!rec.client_ip) return;
-        const key = rec.client_ip;
-        const existing = map.get(key);
-        if (!existing) {
-            map.set(key, {
-                id: rec.id,
-                client_ip: rec.client_ip,
-                location: rec.location,
-                asn: rec.asn,
-                isp: rec.isp,
-                ping_ms: rec.ping_ms,
-                ping_min_ms: rec.ping_min_ms,
-                ping_max_ms: rec.ping_max_ms,
-                download_single_mbps: rec.speedtest_type === 'single' ? rec.download_mbps : undefined,
-                upload_single_mbps: rec.speedtest_type === 'single' ? rec.upload_mbps : undefined,
-                download_multi_mbps: rec.speedtest_type === 'multi' ? rec.download_mbps : undefined,
-                upload_multi_mbps: rec.speedtest_type === 'multi' ? rec.upload_mbps : undefined,
-                test_target: rec.test_target,
-                timestamp: rec.timestamp
-            });
-        } else {
-            if (new Date(rec.timestamp) > new Date(existing.timestamp)) {
-                existing.id = rec.id;
-                existing.location = rec.location;
-                existing.asn = rec.asn;
-                existing.isp = rec.isp;
-                existing.test_target = rec.test_target;
-                existing.timestamp = rec.timestamp;
-            }
-            if (typeof rec.ping_ms === 'number') {
-                existing.ping_ms = rec.ping_ms;
-                existing.ping_min_ms = rec.ping_min_ms;
-                existing.ping_max_ms = rec.ping_max_ms;
-            }
-            if (rec.speedtest_type === 'single') {
-                existing.download_single_mbps = rec.download_mbps;
-                existing.upload_single_mbps = rec.upload_mbps;
-            }
-            if (rec.speedtest_type === 'multi') {
-                existing.download_multi_mbps = rec.download_mbps;
-                existing.upload_multi_mbps = rec.upload_mbps;
-            }
-        }
-    });
-    aggregatedRecords = Array.from(map.values());
-    aggregatedRecords.forEach(rec => {
+    currentRecords = data.records || [];
+    totalRecords = data.total || 0;
+    currentPage = page;
+    currentRecords.forEach(rec => {
         const tr = document.createElement('tr');
         tr.innerHTML = `
             <td><input type="checkbox" value="${rec.id}"></td>
@@ -121,15 +87,17 @@ async function loadRecords() {
             <td>${rec.ping_ms ?? ''}</td>
             <td>${rec.ping_min_ms ?? ''}</td>
             <td>${rec.ping_max_ms ?? ''}</td>
-            <td>${rec.download_single_mbps ?? ''}</td>
-            <td>${rec.upload_single_mbps ?? ''}</td>
-            <td>${rec.download_multi_mbps ?? ''}</td>
-            <td>${rec.upload_multi_mbps ?? ''}</td>
+            <td>${rec.download_mbps ?? ''}</td>
+            <td>${rec.upload_mbps ?? ''}</td>
+            <td>${rec.speedtest_type || ''}</td>
             <td>${rec.test_target || ''}</td>
             <td><button data-edit="${rec.id}">Edit</button><button data-del="${rec.id}">Delete</button></td>
         `;
         tbody.appendChild(tr);
     });
+    document.getElementById('selectAll').checked = false;
+    const totalPages = Math.ceil(totalRecords / pageSize) || 1;
+    document.getElementById('pageInfo').textContent = `Page ${currentPage} / ${totalPages}`;
 }
 
 document.getElementById('recordForm').addEventListener('submit', async e => {
@@ -146,29 +114,29 @@ document.getElementById('recordForm').addEventListener('submit', async e => {
         body: JSON.stringify(data)
     });
     form.reset();
-    loadRecords();
+    loadRecords(currentPage);
 });
 
 document.getElementById('recordsTable').addEventListener('click', async e => {
     const editId = e.target.getAttribute('data-edit');
     const delId = e.target.getAttribute('data-del');
     if (editId) {
-        const res = await fetch('/tests');
-        const data = await res.json();
-        const rec = data.records.find(r => r.id == editId);
-        const form = document.getElementById('recordForm');
-        form.id.value = rec.id;
-        form.client_ip.value = rec.client_ip || '';
-        form.location.value = rec.location || '';
-        form.asn.value = rec.asn || '';
-        form.isp.value = rec.isp || '';
-        form.ping_ms.value = rec.ping_ms ?? '';
-        form.ping_min_ms.value = rec.ping_min_ms ?? '';
-        form.ping_max_ms.value = rec.ping_max_ms ?? '';
-        form.download_mbps.value = rec.download_mbps ?? '';
-        form.upload_mbps.value = rec.upload_mbps ?? '';
-        form.speedtest_type.value = rec.speedtest_type || '';
-        form.test_target.value = rec.test_target || '';
+        const rec = currentRecords.find(r => r.id == editId);
+        if (rec) {
+            const form = document.getElementById('recordForm');
+            form.id.value = rec.id;
+            form.client_ip.value = rec.client_ip || '';
+            form.location.value = rec.location || '';
+            form.asn.value = rec.asn || '';
+            form.isp.value = rec.isp || '';
+            form.ping_ms.value = rec.ping_ms ?? '';
+            form.ping_min_ms.value = rec.ping_min_ms ?? '';
+            form.ping_max_ms.value = rec.ping_max_ms ?? '';
+            form.download_mbps.value = rec.download_mbps ?? '';
+            form.upload_mbps.value = rec.upload_mbps ?? '';
+            form.speedtest_type.value = rec.speedtest_type || '';
+            form.test_target.value = rec.test_target || '';
+        }
     }
     if (delId) {
         await fetch('/admin/tests', {
@@ -176,7 +144,7 @@ document.getElementById('recordsTable').addEventListener('click', async e => {
             headers: {'Content-Type': 'application/json'},
             body: JSON.stringify({ids: [Number(delId)]})
         });
-        loadRecords();
+        loadRecords(currentPage);
     }
 });
 
@@ -188,7 +156,7 @@ document.getElementById('deleteSelected').addEventListener('click', async () => 
         headers: {'Content-Type': 'application/json'},
         body: JSON.stringify({ids})
     });
-    loadRecords();
+    loadRecords(currentPage);
 });
 
 document.getElementById('selectAll').addEventListener('change', e => {
@@ -196,12 +164,18 @@ document.getElementById('selectAll').addEventListener('change', e => {
     document.querySelectorAll('#recordsTable tbody input[type=checkbox]').forEach(cb => cb.checked = checked);
 });
 
-let aggregatedRecords = [];
+document.getElementById('prevPage').addEventListener('click', () => {
+    if (currentPage > 1) loadRecords(currentPage - 1);
+});
+document.getElementById('nextPage').addEventListener('click', () => {
+    const totalPages = Math.ceil(totalRecords / pageSize);
+    if (currentPage < totalPages) loadRecords(currentPage + 1);
+});
 
 document.getElementById('exportExcel').addEventListener('click', () => {
-    if (!aggregatedRecords.length) return;
-    const header = ['Client IP','Location','ASN','ISP','Ping Avg(ms)','Ping Min(ms)','Ping Max(ms)','Single DL(Mbps)','Single UL(Mbps)','Multi DL(Mbps)','Multi UL(Mbps)','Target'];
-    const rows = aggregatedRecords.map(r => [r.client_ip || '', r.location || '', r.asn || '', r.isp || '', r.ping_ms ?? '', r.ping_min_ms ?? '', r.ping_max_ms ?? '', r.download_single_mbps ?? '', r.upload_single_mbps ?? '', r.download_multi_mbps ?? '', r.upload_multi_mbps ?? '', r.test_target || '']);
+    if (!currentRecords.length) return;
+    const header = ['Client IP','Location','ASN','ISP','Ping Avg(ms)','Ping Min(ms)','Ping Max(ms)','Download(Mbps)','Upload(Mbps)','Speedtest Type','Target'];
+    const rows = currentRecords.map(r => [r.client_ip || '', r.location || '', r.asn || '', r.isp || '', r.ping_ms ?? '', r.ping_min_ms ?? '', r.ping_max_ms ?? '', r.download_mbps ?? '', r.upload_mbps ?? '', r.speedtest_type || '', r.test_target || '']);
     const csv = [header.join(','), ...rows.map(row => row.join(','))].join('\n');
     const blob = new Blob([csv], {type: 'text/csv;charset=utf-8;'});
     const url = URL.createObjectURL(blob);


### PR DESCRIPTION
## Summary
- add paginated `/admin/tests` endpoint returning total count
- show all test records on admin page with 100-per-page pagination
- cover new endpoint with tests

## Testing
- `pytest`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68948c8f7684832a8dda1b29d98085ef