### PR TITLE
fix: use TestRecord type for initial tests

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -131,7 +131,10 @@ function App() {
         headers: { 'Content-Type': 'application/json' },
         body: '{}',
       });
-      const data: RawTestRecord = await res.json();
+      // The backend returns a complete test record when initiating tests
+      // (with ping results optionally omitted if `skip_ping` is true).
+      // We can treat this response as a standard `TestRecord` for the UI.
+      const data: TestRecord = await res.json();
       setInfo({
         id: data.id,
         timestamp: data.timestamp,


### PR DESCRIPTION
## Summary
- treat `/tests?skip_ping=true` response as `TestRecord`

## Testing
- `npm run lint`
- `npm run build`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6894966c59cc832aa1b6636ce011d93f