### PR TITLE
Handle missing client in _get_client_ip

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -246,7 +246,11 @@ def _get_client_ip(request: Request) -> str:
     forwarded = request.headers.get("x-forwarded-for")
     if forwarded:
         return forwarded.split(",")[0].strip()
-    return request.client.host
+    # ``request.client`` may be ``None`` when running behind certain proxies or in
+    # testing environments.  Guard against this to avoid ``AttributeError``
+    # causing a 500 response.
+    client = request.client
+    return client.host if client else ""
 
 
 @app.get("/admin/login", response_class=HTMLResponse, include_in_schema=False)

--- a/backend/test_main.py
+++ b/backend/test_main.py
@@ -45,6 +45,15 @@ def test_homepage_uses_forwarded_for_header():
     assert ip in ips
 
 
+def test_get_client_ip_handles_missing_client():
+    from starlette.requests import Request
+    from backend.main import _get_client_ip
+
+    scope = {"type": "http", "headers": []}
+    req = Request(scope)
+    assert _get_client_ip(req) == ""
+
+
 def test_ping_endpoint_localhost():
     res = client.get("/ping", params={"host": "127.0.0.1", "count": 1})
     data = res.json()


### PR DESCRIPTION
## Summary
- avoid AttributeError when request.client is None
- test get_client_ip without client info

## Testing
- `cd backend && pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6894983a6a68832aae7f44b877594b24