### PR TITLE
Handle invalid IP values in mask_ip

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -59,15 +59,25 @@ if assets_dir.exists():
 
 
 def mask_ip(ip: str | None) -> str | None:
-    """Partially mask an IPv4 address, gracefully handling ``None`` values.
+    """Return a partially masked representation of ``ip``.
 
-    The previous implementation assumed ``ip`` was always a string which caused
-    ``AttributeError`` when ``None`` was passed (e.g. when a test record had a
-    null ``client_ip``).  This version returns the input unchanged if it is
-    falsy and only performs masking for valid dotted IPv4 strings.
+    This helper is used by the Jinja2 templates when rendering client
+    information.  In production the ``client_ip`` column may contain ``NULL``
+    values (or other unexpected types) which previously resulted in an
+    ``AttributeError`` when ``split`` was called on the non-string object.
+    The function now defensively handles ``None`` and non-string inputs and
+    provides basic masking for both IPv4 and IPv6 addresses.
     """
 
     if not ip:
+        return ip
+    if not isinstance(ip, str):
+        ip = str(ip)
+
+    if ":" in ip:
+        parts = ip.split(":")
+        if len(parts) >= 2:
+            return f"{parts[0]}:***:{parts[-1]}"
         return ip
 
     parts = ip.split(".")

--- a/backend/test_main.py
+++ b/backend/test_main.py
@@ -54,6 +54,15 @@ def test_get_client_ip_handles_missing_client():
     assert _get_client_ip(req) == ""
 
 
+def test_mask_ip_handles_none_and_ipv6():
+    from backend.main import mask_ip
+
+    assert mask_ip(None) is None
+    assert mask_ip("127.0.0.1") == "127.***.***.1"
+    # Basic masking for IPv6 addresses; exact pattern is less important
+    assert mask_ip("2001:db8::1").startswith("2001:")
+
+
 def test_ping_endpoint_localhost():
     res = client.get("/ping", params={"host": "127.0.0.1", "count": 1})
     data = res.json()


### PR DESCRIPTION
## Summary
- Harden `mask_ip` helper against `None` and non-string inputs and add IPv6 masking
- Add regression test covering `mask_ip` with `None` and IPv6 addresses

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6894bed82d24832a8dcbccb82e88be56