### PR TITLE
fix: assert client IP when running tests

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -143,8 +143,8 @@ function App() {
       });
       if (data?.client_ip) {
         const steps = [
-          { msg: 'Ping', fn: () => runPing(data.client_ip) },
-          { msg: 'Traceroute', fn: () => runTraceroute(data.client_ip, true) },
+          { msg: 'Ping', fn: () => runPing(data.client_ip!) },
+          { msg: 'Traceroute', fn: () => runTraceroute(data.client_ip!, true) },
           {
             msg: 'Speedtest',
             fn: async () => {


### PR DESCRIPTION
## Summary
- ensure `client_ip` is treated as non-null when running ping or traceroute

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6894c46264e0832a9d2987780dd1df73