### PR TITLE
Handle admin record fetch errors

### DIFF
--- a/backend/templates/admin.html
+++ b/backend/templates/admin.html
@@ -72,6 +72,15 @@ let currentRecords = [];
 async function loadRecords(page = 1) {
     const offset = (page - 1) * pageSize;
     const res = await fetch(`/admin/tests?offset=${offset}&limit=${pageSize}`);
+    if (res.status === 403) {
+        // User is required to change the default password before accessing data
+        window.location.href = '/admin/password';
+        return;
+    }
+    if (!res.ok) {
+        console.error('Failed to load records', res.status);
+        return;
+    }
     const data = await res.json();
     const tbody = document.querySelector('#recordsTable tbody');
     tbody.innerHTML = '';


### PR DESCRIPTION
## Summary
- Redirect to password change page when admin data fetch is forbidden
- Log other fetch failures instead of silently hiding records

## Testing
- `cd backend && pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6894c487e938832a9e2f0e0bd4d20ac1