### PR TITLE
Prevent loading screen from hanging after speedtest

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -161,7 +161,7 @@ function App() {
     } catch (err) {
       console.error('Failed to run initial tests', err);
     } finally {
-      await loadRecords();
+      loadRecords().catch((err) => console.error('Failed to load previous tests', err));
       setLoading(false);
     }
   };
@@ -414,10 +414,13 @@ function App() {
         ...(prev || {}),
         [threads === 1 ? 'single' : 'multi']: { down, up },
       }));
-      const recs = await loadRecords();
-      if (recs.length > 0) {
-        setInfo(recs[0]);
-      }
+      loadRecords()
+        .then((recs) => {
+          if (recs.length > 0) {
+            setInfo(recs[0]);
+          }
+        })
+        .catch((err) => console.error('Failed to load previous tests', err));
     })();
 
     speedtestPromise.catch((err) => {


### PR DESCRIPTION
## Summary
- Load test records asynchronously during initial run so UI stops blocking if record fetch stalls
- Avoid awaiting record fetch after speedtest completion

## Testing
- `npm run lint`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6894c8c2044c832a94cce7a69a64fae8