### PR TITLE
feat: improve speed test layout with bar charts

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -660,7 +660,7 @@ function App() {
                 <span className="mr-1">⬇️</span>Download
               </div>
               <div className="text-lg">
-                {currentDownloadSpeed.toFixed(2)}
+                {currentDownloadSpeed.toFixed(2)} Mbps
               </div>
             </div>
             <div className="bg-black bg-opacity-50 rounded p-2 w-40">
@@ -668,24 +668,26 @@ function App() {
                 <span className="mr-1">⬆️</span>Upload
               </div>
               <div className="text-lg">
-                {currentUploadSpeed.toFixed(2)}
+                {currentUploadSpeed.toFixed(2)} Mbps
               </div>
             </div>
           </div>
-          {downloadSpeeds.length > 0 && (
-            <SpeedChart
-              title="Download Speed"
-              speeds={downloadSpeeds}
-              color="#00ffff"
-            />
-          )}
-          {uploadSpeeds.length > 0 && (
-            <SpeedChart
-              title="Upload Speed"
-              speeds={uploadSpeeds}
-              color="#ff00ff"
-            />
-          )}
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4 mt-4 w-full">
+            {downloadSpeeds.length > 0 && (
+              <SpeedChart
+                title="Download Speed"
+                speeds={downloadSpeeds}
+                color="#00ffff"
+              />
+            )}
+            {uploadSpeeds.length > 0 && (
+              <SpeedChart
+                title="Upload Speed"
+                speeds={uploadSpeeds}
+                color="#ff00ff"
+              />
+            )}
+          </div>
           {speedResult && (
             <pre className="whitespace-pre-wrap text-left bg-black bg-opacity-50 p-2 rounded">
               {speedResult.single

--- a/frontend/src/SpeedChart.tsx
+++ b/frontend/src/SpeedChart.tsx
@@ -5,43 +5,37 @@ interface SpeedChartProps {
 }
 
 export default function SpeedChart({ title, speeds, color }: SpeedChartProps) {
-  const width = 300;
+  const width = 320;
   const height = 100;
   const maxSpeed = Math.max(...speeds, 1);
-  const points = speeds
-    .map((s, i) => {
-      const x = (i / Math.max(speeds.length - 1, 1)) * width;
-      const y = height - (s / maxSpeed) * height;
-      return `${x},${y}`;
-    })
-    .join(' ');
+  const barWidth = width / Math.max(speeds.length, 1);
+
   return (
-    <div className="space-y-1">
-      <div>{title}</div>
-      <div className="flex items-center">
-        <svg
-          width={width}
-          height={height}
-          className="bg-black bg-opacity-50 rounded shadow-md"
-        >
-          <polyline
-            points={points}
-            fill="none"
-            stroke={color}
-            strokeWidth={2}
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            style={{ transition: 'all 1s ease' }}
-          />
-        </svg>
-        <div className="flex items-center ml-2 space-x-1 text-xs text-gray-300">
-          <span
-            className="w-3 h-3 rounded-full"
-            style={{ backgroundColor: color }}
-          />
-          <span>{title}</span>
-        </div>
+    <div className="space-y-1 w-full">
+      <div className="flex justify-between items-end">
+        <span>{title}</span>
+        <span className="text-xs text-gray-300">
+          {(speeds[speeds.length - 1] ?? 0).toFixed(2)} Mbps
+        </span>
       </div>
+      <svg
+        viewBox={`0 0 ${width} ${height}`}
+        className="w-full h-24 bg-black bg-opacity-50 rounded shadow-md"
+      >
+        {speeds.map((s, i) => {
+          const h = (s / maxSpeed) * height;
+          return (
+            <rect
+              key={i}
+              x={i * barWidth}
+              y={height - h}
+              width={Math.max(barWidth - 1, 1)}
+              height={h}
+              fill={color}
+            />
+          );
+        })}
+      </svg>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- display real-time download and upload speeds using responsive bar charts
- reorganize SpeedTest section for clearer speed readouts and units

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6894c989f1d4832aa4683e5f567b98c5