### PR TITLE
style: refine speedtest progress bar

### DIFF
--- a/backend/templates/index.html
+++ b/backend/templates/index.html
@@ -35,6 +35,26 @@
         text-align: left;
         margin: 0;
       }
+      progress {
+        width: 320px;
+        height: 20px;
+        display: block;
+        background-color: #333;
+        border: 1px solid #0f0;
+        border-radius: 4px;
+        overflow: hidden;
+        -webkit-appearance: none;
+        appearance: none;
+      }
+      progress::-webkit-progress-bar {
+        background-color: #333;
+      }
+      progress::-webkit-progress-value {
+        background-color: #0f0;
+      }
+      progress::-moz-progress-bar {
+        background-color: #0f0;
+      }
     </style>
   </head>
   <body>


### PR DESCRIPTION
## Summary
- restyle SpeedTest progress indicators with fixed width and neon theme

## Testing
- `pytest`
- `npm test` (fails: Could not read package.json)


------
https://chatgpt.com/codex/tasks/task_e_6894cc0d6c64832a8c44b27dd15e22fd