### PR TITLE
fix: remove loading border and avoid duplicate test records

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -585,6 +585,36 @@ def create_test(
     dl = data.pop("download_mbps", None)
     ul = data.pop("upload_mbps", None)
 
+    if skip_ping and dl is None and ul is None and not any(
+        data.get(k) is not None
+        for k in ("ping_ms", "ping_min_ms", "ping_max_ms", "mtr_result", "iperf_result")
+    ):
+        now = datetime.utcnow()
+        mapped = {
+            "client_ip": client_ip,
+            "user_agent": user_agent,
+            "location": data.get("location"),
+            "asn": data.get("asn"),
+            "isp": data.get("isp"),
+            "ping_ms": data.get("ping_ms"),
+            "ping_min_ms": data.get("ping_min_ms"),
+            "ping_max_ms": data.get("ping_max_ms"),
+            "single_dl_mbps": None,
+            "single_ul_mbps": None,
+            "multi_dl_mbps": None,
+            "multi_ul_mbps": None,
+            "mtr_result": data.get("mtr_result"),
+            "iperf_result": data.get("iperf_result"),
+            "test_target": data.get("test_target"),
+            "timestamp": now,
+            "time_hour": (
+                to_shanghai(now)
+                .replace(minute=0, second=0, microsecond=0)
+                .strftime("%I:00%p")
+            ),
+        }
+        return schemas.TestRecord(id=0, **mapped)
+
     ten_minutes_ago = datetime.utcnow() - timedelta(minutes=10)
     existing = (
         db.query(models.TestRecord)

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -29,7 +29,6 @@
         justify-content: center;
         gap: 1rem;
         padding: 1.25rem 1.5rem;
-        border: 1px solid rgba(0, 255, 0, 0.12);
         border-radius: 10px;
         box-shadow: 0 0 40px rgba(0, 255, 0, 0.05);
         max-width: min(90vw, 960px);

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -465,7 +465,7 @@ function App() {
     return (
       <div className="min-h-screen bg-gradient-to-br from-black via-green-900 to-black text-green-400 flex items-center justify-center p-4 leading-[1.4]">
         <div
-          className="flex flex-col items-center space-y-4 p-5 border border-green-500/20 rounded-lg shadow-[0_0_40px_rgba(0,255,0,0.05)] max-w-[min(90vw,960px)] text-center"
+          className="flex flex-col items-center space-y-4 p-5 rounded-lg shadow-[0_0_40px_rgba(0,255,0,0.05)] max-w-[min(90vw,960px)] text-center"
           role="status"
           aria-live="polite"
           aria-busy="true"


### PR DESCRIPTION
## Summary
- drop green border from loading screen to keep ASCII art aligned
- skip recording empty `skip_ping` calls to prevent duplicate test records

## Testing
- `pytest -q`
- `cd frontend && npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6895c4739448832aad9433ca63e32f13