### PR TITLE
fix: align ASCII logo in loading screen

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -58,7 +58,7 @@ const ASCII_LOGO = [
 function AsciiLogo() {
   return (
     <pre
-      className="mx-auto mb-2 overflow-hidden whitespace-pre font-mono leading-[1.1] w-[80ch]"
+      className="mx-auto mb-2 overflow-hidden whitespace-pre font-mono leading-[1.1] w-[80ch] text-left"
       style={{
         textShadow: '0 0 6px rgba(0,255,0,0.25)',
         fontVariantLigatures: 'none',


### PR DESCRIPTION
## Summary
- keep ASCII art left-aligned on loading screen

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6895cf9f3ef8832a891169cf06bc6a90