### PR TITLE
fix: center loading logo and enable scrolling

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -18,7 +18,6 @@
         min-height: 100vh;
         height: 100%;
         margin: 0;
-        overflow: hidden;
       }
       body {
         display: flex;
@@ -51,12 +50,13 @@
 
       .ascii-logo {
         white-space: pre;
-        margin: 0 0 0.5rem 0;
+        margin: 0 auto 0.5rem;
         line-height: 1.1;
         text-shadow: 0 0 6px rgba(0, 255, 0, 0.25);
         overflow: hidden;
         width: 80ch;
         max-width: 80ch;
+        text-align: center;
         font-family: 'JetBrains Mono', ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace;
         font-variant-ligatures: none;
         font-kerning: none;

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -89,8 +89,8 @@ function App() {
       html.style.overflow = 'hidden';
       document.body.style.overflow = 'hidden';
     } else {
-      html.style.overflow = '';
-      document.body.style.overflow = '';
+      html.style.overflow = 'auto';
+      document.body.style.overflow = 'auto';
     }
   }, [loading]);
 


### PR DESCRIPTION
## Summary
- center ASCII logo on loading screen
- restore page scrolling after load

## Testing
- `npm test` (fails: Missing script)
- `npm run lint`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6895f44f1d04832a9d5c13054eaab839