### PR TITLE
fix: center ASCII logo and enable probe scrolling

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -16,13 +16,9 @@
       }
       html, body, #root {
         min-height: 100vh;
-        height: 100%;
         margin: 0;
       }
       body {
-        display: flex;
-        align-items: center;
-        justify-content: center;
         background: linear-gradient(to bottom right, #000000, #003300, #001a00);
         background-attachment: fixed;
         background-size: cover;
@@ -46,6 +42,8 @@
         box-shadow: 0 0 40px rgba(0, 255, 0, 0.05);
         max-width: min(90vw, 960px);
         text-align: center;
+        margin: 0 auto;
+        min-height: 100vh;
       }
 
       .ascii-logo {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -58,7 +58,7 @@ const ASCII_LOGO = [
 function AsciiLogo() {
   return (
     <pre
-      className="mx-auto mb-2 overflow-hidden whitespace-pre font-mono leading-[1.1] w-[80ch] text-left"
+      className="mx-auto mb-2 overflow-hidden whitespace-pre font-mono leading-[1.1] w-[80ch] text-center"
       style={{
         textShadow: '0 0 6px rgba(0,255,0,0.25)',
         fontVariantLigatures: 'none',


### PR DESCRIPTION
## Summary
- center ASCII logo in the homepage
- allow mouse scrolling on the probe page

## Testing
- `npm run lint`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6895f8ab6290832a91d322ae4627dc25