### PR TITLE
feat: left-align ASCII logo

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -48,13 +48,14 @@
 
       .ascii-logo {
         white-space: pre;
-        margin: 0 auto 0.5rem;
+        margin: 0 0 0.5rem;
         line-height: 1.1;
         text-shadow: 0 0 6px rgba(0, 255, 0, 0.25);
         overflow: hidden;
         width: 80ch;
         max-width: 80ch;
-        text-align: center;
+        text-align: left;
+        align-self: flex-start;
         font-family: 'JetBrains Mono', ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace;
         font-variant-ligatures: none;
         font-kerning: none;
@@ -128,7 +129,7 @@ __      _______   _____ _______ ______          ___   _
    \  /  | |     ____) |  | | | |__| | \  /\  /  | |\  |
     \/   |_|    |_____(_) |_|  \____/   \/  \/   |_| \_|
 
-                     V P S . T O W N
+V P S . T O W N
 
 _   _           _        _____           _
 | \ | |         | |      |  __ \         | |
@@ -137,7 +138,7 @@ _   _           _        _____           _
 | |\  | (_) | (_| |  __/ | |   | | | (_) | |_) |  __/
 |_| \_|\___/ \__,_|\___| |_|   |_|  \___/|_.__/ \___|
 
-                         N o d e P r o b e
+N o d e P r o b e
           
         </pre>
         <span class="sr-only">正在加载，请稍候</span>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -43,23 +43,23 @@ const ASCII_LOGO = [
   "   \\  /  | |     ____) |  | | | |__| | \\  /\\  /  | |\\  |",
   "    \\/   |_|    |_____(_) |_|  \\____/   \\/  \\/   |_| \\_|",
   "",
-  "                     V P S . T O W N",
+  "V P S . T O W N",
   "",
-  " _   _           _        _____           _",
+  "_   _           _        _____           _",
   "| \\ | |         | |      |  __ \\         | |",
   "|  \\| | ___   __| | ___  | |__) | __ ___ | |__   ___",
   "| . ` |/ _ \\ / _` |/ _ \\ |  ___/ '__/ _ \\| '_ \\ / _ \\",
   "| |\\  | (_) | (_| |  __/ | |   | | | (_) | |_) |  __/",
   "|_| \\_|\\___/ \\__,_|\\___| |_|   |_|  \\___/|_.__/ \\___|",
   "",
-  "                         N o d e P r o b e"
+  "N o d e P r o b e"
 ].join('\n');
 
 function AsciiLogo() {
-  return (
-    <pre
-      className="mx-auto mb-2 overflow-hidden whitespace-pre font-mono leading-[1.1] w-[80ch] text-center"
-      style={{
+    return (
+      <pre
+        className="mb-2 overflow-hidden whitespace-pre font-mono leading-[1.1] w-[80ch] self-start text-left"
+        style={{
         textShadow: '0 0 6px rgba(0,255,0,0.25)',
         fontVariantLigatures: 'none',
         fontKerning: 'none',


### PR DESCRIPTION
## Summary
- left-align ASCII logo in loading screen and app
- adjust styling so ASCII art is not centered

## Testing
- `npm run lint`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6895fb062afc832a9381aec0309e4f28