### PR TITLE
feat: center ASCII logo and clean footer

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -43,22 +43,18 @@ const ASCII_LOGO = [
   "   \\  /  | |     ____) |  | | | |__| | \\  /\\  /  | |\\  |",
   "    \\/   |_|    |_____(_) |_|  \\____/   \\/  \\/   |_| \\_|",
   "",
-  "V P S . T O W N",
-  "",
   "_   _           _        _____           _",
   "| \\ | |         | |      |  __ \\         | |",
   "|  \\| | ___   __| | ___  | |__) | __ ___ | |__   ___",
   "| . ` |/ _ \\ / _` |/ _ \\ |  ___/ '__/ _ \\| '_ \\ / _ \\",
   "| |\\  | (_) | (_| |  __/ | |   | | | (_) | |_) |  __/",
-  "|_| \\_|\\___/ \\__,_|\\___| |_|   |_|  \\___/|_.__/ \\___|",
-  "",
-  "N o d e P r o b e"
+  "|_| \\_|\\___/ \\__,_|\\___| |_|   |_|  \\___/|_.__/ \\___|"
 ].join('\n');
 
 function AsciiLogo() {
     return (
       <pre
-        className="mb-2 overflow-hidden whitespace-pre font-mono leading-[1.1] w-[80ch] self-start text-left"
+        className="mb-2 overflow-hidden whitespace-pre font-mono leading-[1.1] w-[80ch] mx-auto text-center"
         style={{
         textShadow: '0 0 6px rgba(0,255,0,0.25)',
         fontVariantLigatures: 'none',


### PR DESCRIPTION
## Summary
- center ASCII logo via Tailwind classes
- drop extraneous footer text from ASCII art

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6895fd8216d4832aaf52240520f77c0f