### PR TITLE
Add Unicode text sanitization utilities

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -3,6 +3,8 @@ from datetime import datetime, timezone, timedelta
 
 import re
 import os
+os.environ.setdefault("LC_CTYPE", "en_US.UTF-8")
+os.environ.setdefault("LANG", "en_US.UTF-8")
 import secrets
 import hashlib
 import hmac

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -7,4 +7,5 @@ jinja2
 httpx
 itsdangerous
 python-multipart
+wcwidth
 

--- a/backend/test_text_utils.py
+++ b/backend/test_text_utils.py
@@ -1,0 +1,20 @@
+from backend.text_utils import sanitize_text, visual_width, pad_to, find_suspects
+
+
+def test_sanitize_text_removes_combining_marks():
+    original = "e\u0308"  # 'e' + combining diaeresis
+    assert sanitize_text(original) == "ë"
+
+
+def test_pad_to_counts_visual_width():
+    original = "e\u0308"
+    padded = pad_to(original, 2)
+    assert visual_width(padded) == 2
+    assert padded.endswith(" ")
+
+
+def test_find_suspects_identifies_combining_mark():
+    original = "e\u0308"
+    suspects = find_suspects(original)
+    codes = [item[2] for item in suspects]
+    assert "U+0308" in codes

--- a/backend/text_utils.py
+++ b/backend/text_utils.py
@@ -1,0 +1,69 @@
+"""Utilities for safer Unicode text handling.
+
+Provides helpers to sanitize text by removing combining marks and normalizing
+characters, compute visual width in terminal environments and pad strings to a
+desired display width.  These helpers mitigate issues with ambiguous or
+full-width characters when rendering aligned text.
+"""
+
+from __future__ import annotations
+
+import unicodedata
+from wcwidth import wcwidth
+
+
+def sanitize_text(s: str) -> str:
+    """Return ``s`` normalized and without combining marks.
+
+    The function first applies NFKC normalization which converts full-width
+    variants to their ASCII equivalents and composes decomposed characters.  It
+    then removes any remaining combining marks (category ``Mn``) so that the
+    resulting string contains only standalone printable characters.
+    """
+
+    # Normalize to NFKC form to collapse compatible characters
+    s = unicodedata.normalize("NFKC", s)
+    # Remove all combining marks
+    return "".join(ch for ch in s if unicodedata.category(ch) != "Mn")
+
+
+def visual_width(s: str) -> int:
+    """Return the display width of ``s`` in columns.
+
+    Characters with undefined width are treated as width 1 for robustness.
+    """
+
+    s = sanitize_text(s)
+    total = 0
+    for ch in s:
+        w = wcwidth(ch)
+        total += 1 if w < 0 else w
+    return total
+
+
+def pad_to(s: str, width: int) -> str:
+    """Pad ``s`` on the right with spaces so its visual width equals ``width``."""
+
+    s = sanitize_text(s)
+    pad = width - visual_width(s)
+    return s + " " * max(pad, 0)
+
+
+def find_suspects(s: str):
+    """Return a list of suspicious characters in ``s`` for debugging.
+
+    Each element in the returned list is a tuple ``(index, character,
+    codepoint, category, east_asian_width)``.  Characters are considered
+    suspicious if they are combining marks, full-width, wide or ambiguous
+    according to ``unicodedata.east_asian_width`` or if their codepoint is
+    non-ASCII.
+    """
+
+    suspects = []
+    for i, ch in enumerate(s):
+        cat = unicodedata.category(ch)
+        eaw = unicodedata.east_asian_width(ch)
+        if cat == "Mn" or eaw in {"F", "W", "A"} or ord(ch) > 127:
+            suspects.append((i, ch, f"U+{ord(ch):04X}", cat, eaw))
+    return suspects
+


### PR DESCRIPTION
## Summary
- add `text_utils` module for sanitizing strings, computing display width, and safe padding
- ensure LC_CTYPE/LANG default to `en_US.UTF-8` to standardize ambiguous character widths
- include wcwidth dependency and tests for the new utilities

## Testing
- `pip install -r backend/requirements.txt`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68960251b48c832a900d7990d2647469