### PR TITLE
Use fixed pixel banner font and sanitize ASCII art

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -38,6 +38,7 @@ import tempfile
 from starlette.middleware.sessions import SessionMiddleware
 
 from . import models, schemas, database
+from .text_utils import sanitize_banner
 
 # Configure logging so Docker logs include informative startup messages
 logging.basicConfig(level=logging.INFO)
@@ -58,6 +59,17 @@ frontend_dist = Path(__file__).resolve().parent.parent / "frontend" / "dist"
 assets_dir = frontend_dist / "assets"
 if assets_dir.exists():
     app.mount("/assets", StaticFiles(directory=assets_dir), name="assets")
+
+
+ASCII_BANNER = sanitize_banner(
+    """
+__     ______  ____ _____ _____        ___   _       _   _  ___  ____  _____   ____            _
+\ \   / /  _ \/ ___|_   _/ _ \ \      / / \ | |     | \ | |/ _ \|  _ \| ____| |  _ \ _ __ ___ | |__   ___
+ \ \ / /| |_) \___ \ | || | | \ \ /\ / /|  \| |     |  \| | | | | | | |  _|   | |_) | '__/ _ \| '_ \ / _ \
+  \ V / |  __/ ___) || || |_| |\ V  V / | |\  |     | |\  | |_| | |_| | |___  |  __/| | | (_) | |_) |  __/
+   \_/  |_|   |____(_)_| \___/  \_/\_/  |_| \_|     |_| \_|\___/|____/|_____| |_|   |_|  \___/|_.__/ \___|
+"""
+)
 
 
 def mask_ip(ip: str | None) -> str | None:
@@ -477,7 +489,8 @@ def probe_page(request: Request, db: Session = Depends(get_db)):
         return FileResponse(index_file)
 
     return templates.TemplateResponse(
-        "index.html", {"request": request, "info": db_record}
+        "index.html",
+        {"request": request, "info": db_record, "ascii_banner": ASCII_BANNER},
     )
 @app.get("/api")
 def api_root():

--- a/backend/templates/index.html
+++ b/backend/templates/index.html
@@ -34,6 +34,13 @@
         display: inline-block;
         text-align: left;
         margin: 0;
+        white-space: pre;
+        font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, "Liberation Mono", monospace;
+        font-variant-ligatures: none;
+        -webkit-font-smoothing: antialiased;
+        letter-spacing: 0;
+        font-size: 28px;
+        line-height: 1.1;
       }
       progress {
         width: 320px;
@@ -59,15 +66,7 @@
   </head>
   <body>
     <div class="banner">
-      <pre>
-__     ______  ____ _____ _____        ___   _       _   _  ___  ____  _____   ____            _
-\ \   / /  _ \/ ___|_   _/ _ \ \      / / \ | |     | \ | |/ _ \|  _ \| ____| |  _ \ _ __ ___ | |__   ___
- \ \ / /| |_) \___ \ | || | | \ \ /\ / /|  \| |     |  \| | | | | | | |  _|   | |_) | '__/ _ \| '_ \ / _ \
-  \ V / |  __/ ___) || || |_| |\ V  V / | |\  |     | |\  | |_| | |_| | |___  |  __/| | | (_) | |_) |  __/
-   \_/  |_|   |____(_)_| \___/  \_/\_/  |_| \_|     |_| \_|\___/|____/|_____| |_|   |_|  \___/|_.__/ \___|
-
-
-      </pre>
+      <pre>{{ ascii_banner | safe }}</pre>
     </div>
 
     <h1>Your Connection Info</h1>

--- a/backend/test_text_utils.py
+++ b/backend/test_text_utils.py
@@ -1,4 +1,10 @@
-from backend.text_utils import sanitize_text, visual_width, pad_to, find_suspects
+from backend.text_utils import (
+    sanitize_text,
+    visual_width,
+    pad_to,
+    find_suspects,
+    sanitize_banner,
+)
 
 
 def test_sanitize_text_removes_combining_marks():
@@ -18,3 +24,8 @@ def test_find_suspects_identifies_combining_mark():
     suspects = find_suspects(original)
     codes = [item[2] for item in suspects]
     assert "U+0308" in codes
+
+
+def test_sanitize_banner_removes_risky_chars():
+    original = "e\u0308\u3000\uFF01"
+    assert sanitize_banner(original) == "ë !"

--- a/backend/text_utils.py
+++ b/backend/text_utils.py
@@ -8,6 +8,7 @@ full-width characters when rendering aligned text.
 
 from __future__ import annotations
 
+import re
 import unicodedata
 from wcwidth import wcwidth
 
@@ -25,6 +26,20 @@ def sanitize_text(s: str) -> str:
     s = unicodedata.normalize("NFKC", s)
     # Remove all combining marks
     return "".join(ch for ch in s if unicodedata.category(ch) != "Mn")
+
+
+RISKY = re.compile(
+    r"[\u0300-\u036F]"  # combining marks
+    r"|\u3000"            # full-width space
+    r"|[\uFF00-\uFF65]"  # full-width ASCII variants
+)
+
+
+def sanitize_banner(s: str) -> str:
+    """Remove characters that tend to disrupt monospace ASCII art."""
+
+    s = unicodedata.normalize("NFKC", s)
+    return RISKY.sub("", s)
 
 
 def visual_width(s: str) -> int:

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -63,7 +63,7 @@
         tab-size: 4;
         -webkit-font-smoothing: antialiased;
         text-rendering: geometricPrecision;
-        font-size: clamp(10px, 1.6vw, 22px);
+        font-size: 28px;
       }
       .spinner {
         width: 48px;

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -35,7 +35,12 @@ function maskIp(ip?: string | null) {
   return ip;
 }
 
-const ASCII_LOGO = [
+const RISKY = /[\u0300-\u036F]|\u3000|[\uFF00-\uFF65]/g;
+function sanitizeBanner(s: string): string {
+  return s.normalize('NFKC').replace(RISKY, '');
+}
+
+const ASCII_LOGO = sanitizeBanner([
   "__      _______   _____ _______ ______          ___   _",
   "\\ \\    / /  __ \\ / ____|__   __/ __ \\ \\        / / \\ | |",
   " \\ \\  / /| |__) | (___    | | | |  | \\ \\  /\\  / /|  \\| |",
@@ -49,7 +54,7 @@ const ASCII_LOGO = [
   "| . ` |/ _ \\ / _` |/ _ \\ |  ___/ '__/ _ \\| '_ \\ / _ \\",
   "| |\\  | (_) | (_| |  __/ | |   | | | (_) | |_) |  __/",
   "|_| \\_|\\___/ \\__,_|\\___| |_|   |_|  \\___/|_.__/ \\___|"
-].join('\n');
+].join('\n'));
 
 function AsciiLogo() {
     return (
@@ -61,7 +66,7 @@ function AsciiLogo() {
         fontKerning: 'none',
         letterSpacing: 0,
         tabSize: 4,
-        fontSize: 'clamp(10px, 1.6vw, 22px)',
+        fontSize: '28px',
         WebkitFontSmoothing: 'antialiased',
         textRendering: 'geometricPrecision',
       }}


### PR DESCRIPTION
## Summary
- Eliminate scale-based banner rendering by using integer pixel fonts and consistent line height
- Add Unicode `sanitize_banner` helper to strip risky characters from ASCII art and apply in backend/frontend
- Include regression test for banner sanitization

## Testing
- `npm run lint`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689609848464832aa960f9b91e11b50c