### PR TITLE
chore: clean ascii banner

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -121,7 +121,6 @@
       <!-- Status region for screen readers -->
       <div class="loading" role="status" aria-live="polite" aria-busy="true">
         <pre class="ascii-logo">
-
 __      _______   _____ _______ ______          ___   _
 \ \    / /  __ \ / ____|__   __/ __ \ \        / / \ | |
  \ \  / /| |__) | (___    | | | |  | \ \  /\  / /|  \| |
@@ -135,8 +134,6 @@ _   _           _        _____           _
 | . ` |/ _ \ / _` |/ _ \ |  ___/ '__/ _ \| '_ \ / _ \
 | |\  | (_) | (_| |  __/ | |   | | | (_) | |_) |  __/
 |_| \_|\___/ \__,_|\___| |_|   |_|  \___/|_.__/ \___|
-
-          
         </pre>
         <span class="sr-only">正在加载，请稍候</span>
         <div class="spinner" aria-hidden="true"></div>


### PR DESCRIPTION
## Summary
- tidy ASCII banner in loading screen by removing stray blank lines

## Testing
- `npm run lint`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68960f6b7d70832ab5c5c14758f7e27a