### PR TITLE
fix: prevent double initialization on probe page

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -156,9 +156,12 @@ function App() {
   const downloadControllers = useRef<AbortController[]>([]);
   const uploadXhrs = useRef<XMLHttpRequest[]>([]);
 
-    useEffect(() => {
-      runInitialTests();
-    }, []); // eslint-disable-line react-hooks/exhaustive-deps
+  const hasRunInitial = useRef(false);
+  useEffect(() => {
+    if (hasRunInitial.current) return;
+    hasRunInitial.current = true;
+    runInitialTests();
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
 
   const runInitialTests = async () => {


### PR DESCRIPTION
## Summary
- prevent duplicate initial test runs to stop probe page from refreshing twice

## Testing
- `npm run lint`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689612201dc4832a89a46067895d061f