### PR TITLE
Fix ASCII logo misalignment on reload

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -59,7 +59,7 @@ const ASCII_LOGO = sanitizeBanner([
 function AsciiLogo() {
     return (
       <pre
-        className="mb-2 overflow-hidden whitespace-pre font-mono w-[80ch] mx-auto text-center"
+        className="mb-2 overflow-hidden whitespace-pre font-mono w-[80ch] mx-auto text-left"
         style={{
         textShadow: '0 0 6px rgba(0,255,0,0.25)',
         fontVariantLigatures: 'none',


### PR DESCRIPTION
## Summary
- ensure ASCII logo is always left-aligned to prevent shifting on subsequent refreshes

## Testing
- `npm run lint`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689613abb9d0832ab795ba692c3ddaa3