### PR TITLE
feat: refine dashboard layout and speed test

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -577,30 +577,31 @@ function App() {
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-black via-green-900 to-black text-green-400 p-4 leading-[1.4]">
-      <div className="w-full max-w-3xl mx-auto space-y-8">
+      <div className="app space-y-8">
         <AsciiLogo />
-        {info ? (
-          <TestSection title="Your Connection Info">
-            <div>IP: {maskIp(info.client_ip)}</div>
-            <div>Location: {info.location || 'Unknown'}</div>
-            <div>ASN: {info.asn || 'Unknown'}</div>
-            <div>ISP: {info.isp || 'Unknown'}</div>
-            {typeof info.ping_ms === 'number' && (
-              <div className={getPingColor(info.ping_ms)}>
-                Ping: {info.ping_ms.toFixed(2)} ms
+        <div className="dashboard">
+          {info ? (
+            <TestSection title="Your Connection Info">
+              <div>IP: {maskIp(info.client_ip)}</div>
+              <div>Location: {info.location || 'Unknown'}</div>
+              <div>ASN: {info.asn || 'Unknown'}</div>
+              <div>ISP: {info.isp || 'Unknown'}</div>
+              {typeof info.ping_ms === 'number' && (
+                <div className={getPingColor(info.ping_ms)}>
+                  Ping: {info.ping_ms.toFixed(2)} ms
+                </div>
+              )}
+              <div className="text-sm text-gray-400">
+                Recorded at: {new Date(info.timestamp).toLocaleString()}
               </div>
-            )}
-            <div className="text-sm text-gray-400">
-              Recorded at: {new Date(info.timestamp).toLocaleString()}
-            </div>
-          </TestSection>
-        ) : (
-          <TestSection title="Your Connection Info">
-            <div>No info available</div>
-          </TestSection>
-        )}
+            </TestSection>
+          ) : (
+            <TestSection title="Your Connection Info">
+              <div>No info available</div>
+            </TestSection>
+          )}
 
-        <TestSection title="Recent Tests">
+          <TestSection title="Recent Tests">
           {sortedRecords.length > 0 ? (
             <div className="overflow-x-auto">
               <table className="min-w-full text-sm text-left border border-green-600 border-collapse">
@@ -727,119 +728,102 @@ function App() {
           )}
         </TestSection>
 
-        <TestSection title="Speed Test">
-          <div className="space-y-4 border border-[rgba(0,255,0,0.2)] rounded p-4 bg-black/40">
-            <div className="space-y-2">
-              <div className="flex justify-center space-x-2">
-                <button
-                  className="px-4 py-1 rounded bg-green-600 text-black"
-                  disabled={speedRunning}
-                  onClick={() =>
-                    runSpeedtest(100 * 1024 * 1024, 50 * 1024 * 1024, 1)
-                  }
-                >
-                  [单线程]100M
-                </button>
-                <button
-                  className="px-4 py-1 rounded bg-green-600 text-black"
-                  disabled={speedRunning}
-                  onClick={() =>
-                    runSpeedtest(500 * 1024 * 1024, 200 * 1024 * 1024, 1)
-                  }
-                >
-                  [单线程]500M
-                </button>
-                <button
-                  className="px-4 py-1 rounded bg-green-600 text-black"
-                  disabled={speedRunning}
-                  onClick={() =>
-                    runSpeedtest(1024 * 1024 * 1024, 500 * 1024 * 1024, 1)
-                  }
-                >
-                  [单线程]1G
-                </button>
-              </div>
-              <div className="flex justify-center space-x-2">
-                <button
-                  className="px-4 py-1 rounded bg-green-600 text-black"
-                  disabled={speedRunning}
-                  onClick={() =>
-                    runSpeedtest(100 * 1024 * 1024, 50 * 1024 * 1024, 8)
-                  }
-                >
-                  [八线程]100M
-                </button>
-                <button
-                  className="px-4 py-1 rounded bg-green-600 text-black"
-                  disabled={speedRunning}
-                  onClick={() =>
-                    runSpeedtest(500 * 1024 * 1024, 200 * 1024 * 1024, 8)
-                  }
-                >
-                  [八线程]500M
-                </button>
-                <button
-                  className="px-4 py-1 rounded bg-green-600 text-black"
-                  disabled={speedRunning}
-                  onClick={() =>
-                    runSpeedtest(1024 * 1024 * 1024, 500 * 1024 * 1024, 8)
-                  }
-                >
-                  [八线程]1G
-                </button>
-              </div>
-              <div className="flex justify-center">
-                <button
-                  className="px-4 py-1 rounded bg-red-600 text-black"
-                  disabled={!speedRunning}
-                  onClick={stopSpeedtest}
-                >
-                  STOP
-                </button>
-              </div>
-            </div>
-            <div>
-              Download Progress: {formatProgress(downloadProgress)}{' '}
-              <span className="ml-2">
-                ⬇️ Download {currentDownloadSpeed.toFixed(2)} Mbps
-              </span>
-            </div>
-            <div>
-              Upload Progress: {formatProgress(uploadProgress)}{' '}
-              <span className="ml-2">
-                ⬆️ Upload {currentUploadSpeed.toFixed(2)} Mbps
-              </span>
-            </div>
-            <div className="grid grid-cols-1 md:grid-cols-2 gap-4 mt-4 w-full">
-              {downloadSpeeds.length > 0 && (
-                <SpeedChart
-                  title="Download Speed"
-                  speeds={downloadSpeeds}
-                  color="#00ffff"
-                />
-              )}
-              {uploadSpeeds.length > 0 && (
-                <SpeedChart
-                  title="Upload Speed"
-                  speeds={uploadSpeeds}
-                  color="#ff00ff"
-                />
-              )}
-            </div>
-            {speedResult && (
-              <pre className="whitespace-pre-wrap text-left font-mono bg-[rgb(0,40,0)] bg-opacity-70 p-4 rounded">
-                {speedResult.single
-                  ? `Single Thread - ⬇️ ${speedResult.single.down.toFixed(2)} ⬆️ ${speedResult.single.up.toFixed(2)}\n`
-                  : ''}
-                {speedResult.multi
-                  ? `Multi Thread (8) - ⬇️ ${speedResult.multi.down.toFixed(2)} ⬆️ ${speedResult.multi.up.toFixed(2)}`
-                  : ''}
-              </pre>
+        <TestSection title="Speed Test" className="card--wide speedtest">
+          <div className="seg">
+            <button
+              className="seg__btn"
+              disabled={speedRunning}
+              onClick={() => runSpeedtest(100 * 1024 * 1024, 50 * 1024 * 1024, 1)}
+            >
+              单线程100M
+            </button>
+            <button
+              className="seg__btn"
+              disabled={speedRunning}
+              onClick={() => runSpeedtest(500 * 1024 * 1024, 200 * 1024 * 1024, 1)}
+            >
+              单线程500M
+            </button>
+            <button
+              className="seg__btn"
+              disabled={speedRunning}
+              onClick={() => runSpeedtest(1024 * 1024 * 1024, 500 * 1024 * 1024, 1)}
+            >
+              单线程1G
+            </button>
+            <button
+              className="seg__btn"
+              disabled={speedRunning}
+              onClick={() => runSpeedtest(100 * 1024 * 1024, 50 * 1024 * 1024, 8)}
+            >
+              八线程100M
+            </button>
+            <button
+              className="seg__btn"
+              disabled={speedRunning}
+              onClick={() => runSpeedtest(500 * 1024 * 1024, 200 * 1024 * 1024, 8)}
+            >
+              八线程500M
+            </button>
+            <button
+              className="seg__btn"
+              disabled={speedRunning}
+              onClick={() => runSpeedtest(1024 * 1024 * 1024, 500 * 1024 * 1024, 8)}
+            >
+              八线程1G
+            </button>
+          </div>
+          <div className="flex justify-center mt-2">
+            <button
+              className="seg__btn bg-red-600 text-black"
+              disabled={!speedRunning}
+              onClick={stopSpeedtest}
+            >
+              STOP
+            </button>
+          </div>
+          <div className="speedtest__progress mt-4">
+            <span>Download Progress: {formatProgress(downloadProgress)}</span>
+            <span>
+              <span className="icon">⬇️</span> Download {currentDownloadSpeed.toFixed(2)} Mbps
+            </span>
+          </div>
+          <div className="speedtest__progress mt-2">
+            <span>Upload Progress: {formatProgress(uploadProgress)}</span>
+            <span>
+              <span className="icon">⬆️</span> Upload {currentUploadSpeed.toFixed(2)} Mbps
+            </span>
+          </div>
+          <div className="mt-4 grid grid-cols-1 md:grid-cols-2 gap-4 h-full">
+            {downloadSpeeds.length > 0 && (
+              <SpeedChart
+                title="Download Speed"
+                speeds={downloadSpeeds}
+                color="#00ffff"
+              />
+            )}
+            {uploadSpeeds.length > 0 && (
+              <SpeedChart
+                title="Upload Speed"
+                speeds={uploadSpeeds}
+                color="#ff00ff"
+              />
             )}
           </div>
+          {speedResult && (
+            <pre className="whitespace-pre-wrap text-left font-mono bg-[rgb(0,40,0)] bg-opacity-70 p-4 rounded mt-4">
+              {speedResult.single
+                ? `Single Thread - ⬇️ ${speedResult.single.down.toFixed(2)} ⬆️ ${speedResult.single.up.toFixed(2)}\n`
+                : ''}
+              {speedResult.multi
+                ? `Multi Thread (8) - ⬇️ ${speedResult.multi.down.toFixed(2)} ⬆️ ${speedResult.multi.up.toFixed(2)}`
+                : ''}
+            </pre>
+          )}
         </TestSection>
       </div>
     </div>
+  </div>
   );
 }
 

--- a/frontend/src/SpeedChart.tsx
+++ b/frontend/src/SpeedChart.tsx
@@ -5,37 +5,33 @@ interface SpeedChartProps {
 }
 
 export default function SpeedChart({ title, speeds, color }: SpeedChartProps) {
-  const width = 320;
-  const height = 100;
   const maxSpeed = Math.max(...speeds, 1);
-  const barWidth = width / Math.max(speeds.length, 1);
 
   return (
     <div className="space-y-1 w-full border border-[rgba(0,255,0,0.2)] p-2 rounded bg-black/50 shadow-[0_0_10px_rgba(0,255,0,0.1)]">
-      <div className="flex justify-between items-end">
+      <div className="flex justify-between items-center">
         <span className="font-bold">{title}</span>
         <span className="text-xs text-gray-300">
           {(speeds[speeds.length - 1] ?? 0).toFixed(2)} Mbps
         </span>
       </div>
-      <svg
-        viewBox={`0 0 ${width} ${height}`}
-        className="w-full h-24 bg-black bg-opacity-50 rounded"
-      >
-        {speeds.map((s, i) => {
-          const h = (s / maxSpeed) * height;
-          return (
-            <rect
+      <div className="speedtest__chart">
+        <div className="bars">
+          {speeds.map((s, i) => (
+            <div
               key={i}
-              x={i * barWidth}
-              y={height - h}
-              width={Math.max(barWidth - 1, 1)}
-              height={h}
-              fill={color}
-            />
-          );
-        })}
-      </svg>
+              className="bar"
+              style={{
+                height: `${(s / maxSpeed) * 100}%`,
+                background: color,
+                borderColor: color,
+              }}
+            >
+              <span className="value">{s.toFixed(0)}</span>
+            </div>
+          ))}
+        </div>
+      </div>
     </div>
   );
 }

--- a/frontend/src/TestSection.tsx
+++ b/frontend/src/TestSection.tsx
@@ -2,15 +2,18 @@ import type { PropsWithChildren } from 'react';
 
 interface TestSectionProps {
   title: string;
+  className?: string;
 }
 
-export default function TestSection({ title, children }: PropsWithChildren<TestSectionProps>) {
+export default function TestSection({
+  title,
+  className = '',
+  children,
+}: PropsWithChildren<TestSectionProps>) {
   return (
-    <section className="my-5 text-center rounded-lg border border-[rgba(0,255,0,0.2)] bg-black/50 shadow-[0_0_10px_rgba(0,255,0,0.1)]">
-      <h2 className="text-2xl font-bold border-b border-[rgba(0,255,0,0.2)] bg-[rgb(0,50,0)] px-4 py-2 rounded-t-lg">
-        {title}
-      </h2>
-      <div className="p-4 space-y-2">{children}</div>
+    <section className={`card text-center ${className}`}>
+      <h2 className="card__title">{title}</h2>
+      <div className="card__body space-y-2">{children}</div>
     </section>
   );
 }

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -13,4 +13,164 @@
 :root {
   font-family: 'JetBrains Mono', ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
   line-height: 1.4;
+  --container: 1280px;
+  --gap: 16px;
+}
+
+.app {
+  max-width: var(--container);
+  margin: 0 auto;
+  padding: 0 var(--gap);
+}
+
+@media (min-width: 1440px) {
+  :root {
+    --container: 1400px;
+  }
+}
+@media (min-width: 1920px) {
+  :root {
+    --container: 1520px;
+  }
+}
+@media (min-width: 2560px) {
+  :root {
+    --container: 1680px;
+  }
+}
+
+.dashboard {
+  display: grid;
+  grid-template-columns: 1fr;
+  grid-auto-rows: minmax(120px, auto);
+  gap: var(--gap);
+}
+@media (min-width: 1024px) {
+  .dashboard {
+    grid-template-columns: 1fr 1fr;
+  }
+  .card--wide {
+    grid-column: 1 / span 2;
+  }
+}
+
+.card {
+  background: rgba(0, 0, 0, 0.3);
+  border: 1px solid #0a3;
+  border-radius: 8px;
+}
+.card__title {
+  padding: 10px 12px;
+  border-bottom: 1px solid #0a3;
+  font-weight: bold;
+}
+.card__body {
+  padding: 12px;
+}
+
+.speedtest {
+  --chart-h: 360px;
+}
+@media (min-width: 1440px) {
+  .speedtest {
+    --chart-h: 420px;
+  }
+}
+.speedtest__chart {
+  height: var(--chart-h);
+  position: relative;
+  overflow: hidden;
+}
+
+.icon,
+.status-icon,
+.progress-icon {
+  font-size: 12px;
+  line-height: 1;
+  vertical-align: baseline;
+}
+.badge {
+  font-size: 12px;
+  padding: 2px 6px;
+  border: 1px solid #0a3;
+  border-radius: 6px;
+  background: rgba(0, 128, 0, 0.12);
+}
+
+.speedtest__progress {
+  font-size: 12px;
+  line-height: 1.2;
+  display: grid;
+  gap: 4px;
+}
+
+.bars {
+  display: grid;
+  grid-template-columns: repeat(8, minmax(0, 1fr));
+  gap: 8px;
+  height: 100%;
+  align-items: end;
+}
+.bar {
+  background: #2ff;
+  border: 2px solid #0a8;
+  border-radius: 4px 4px 0 0;
+  max-width: 72px;
+  justify-self: center;
+  width: 100%;
+  position: relative;
+}
+.bar--upload {
+  background: #f3f;
+  border-color: #a0a;
+}
+.value {
+  position: absolute;
+  transform: translateY(-100%);
+  font-size: 12px;
+  color: #0f6;
+}
+
+.seg {
+  display: inline-flex;
+  border: 1px solid #0a3;
+  border-radius: 8px;
+  overflow: hidden;
+  background: rgba(0, 128, 0, 0.06);
+}
+.seg__btn {
+  padding: 6px 10px;
+  font-size: 12px;
+  border-right: 1px solid #0a3;
+  cursor: pointer;
+  background: transparent;
+}
+.seg__btn:last-child {
+  border-right: none;
+}
+.seg__btn.is-active {
+  background: rgba(0, 255, 128, 0.12);
+}
+
+@media (max-width: 640px) {
+  .speedtest {
+    --chart-h: 260px;
+  }
+  .seg__btn {
+    padding: 4px 8px;
+    font-size: 11px;
+  }
+  .bars {
+    grid-template-columns: repeat(4, 1fr);
+  }
+}
+
+.text-good {
+  color: #3fe66b;
+}
+.text-warn {
+  color: #d7c94e;
+}
+.text-bad {
+  color: #f45;
 }


### PR DESCRIPTION
## Summary
- constrain app width via responsive container and grid-based dashboard
- restyle reusable card section component
- overhaul speed test controls and charts for compact visuals

## Testing
- `cd frontend && npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68961ce0eca4832ab9b68b05f1fc5458