### PR TITLE
refactor speedtest layout

### DIFF
--- a/frontend/src/SpeedChart.tsx
+++ b/frontend/src/SpeedChart.tsx
@@ -1,36 +1,29 @@
 interface SpeedChartProps {
-  title: string;
   speeds: number[];
   color: string;
 }
 
-export default function SpeedChart({ title, speeds, color }: SpeedChartProps) {
+export default function SpeedChart({ speeds, color }: SpeedChartProps) {
   const maxSpeed = Math.max(...speeds, 1);
 
   return (
-    <div className="space-y-1 w-full border border-[rgba(0,255,0,0.2)] p-2 rounded bg-black/50 shadow-[0_0_10px_rgba(0,255,0,0.1)]">
-      <div className="flex justify-between items-center">
-        <span className="font-bold">{title}</span>
-        <span className="text-xs text-gray-300">
-          {(speeds[speeds.length - 1] ?? 0).toFixed(2)} Mbps
-        </span>
-      </div>
-      <div className="speedtest__chart">
-        <div className="bars">
-          {speeds.map((s, i) => (
-            <div
-              key={i}
-              className="bar"
-              style={{
-                height: `${(s / maxSpeed) * 100}%`,
-                background: color,
-                borderColor: color,
-              }}
-            >
+    <div className="chart">
+      <div className="bars">
+        {speeds.map((s, i) => (
+          <div
+            key={i}
+            className="bar"
+            style={{
+              height: `${(s / maxSpeed) * 100}%`,
+              background: color,
+              borderColor: color,
+            }}
+          >
+            {(s / maxSpeed) * 100 > 5 && (
               <span className="value">{s.toFixed(0)}</span>
-            </div>
-          ))}
-        </div>
+            )}
+          </div>
+        ))}
       </div>
     </div>
   );

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -15,6 +15,8 @@
   line-height: 1.4;
   --container: 1280px;
   --gap: 16px;
+  --green: #0a3;
+  --green-soft: rgba(0, 255, 128, 0.12);
 }
 
 .app {
@@ -56,30 +58,117 @@
 
 .card {
   background: rgba(0, 0, 0, 0.3);
-  border: 1px solid #0a3;
+  border: 1px solid var(--green);
   border-radius: 8px;
 }
 .card__title {
   padding: 10px 12px;
-  border-bottom: 1px solid #0a3;
+  border-bottom: 1px solid var(--green);
   font-weight: bold;
 }
 .card__body {
   padding: 12px;
 }
 
-.speedtest {
-  --chart-h: 360px;
+.card--speed {
+  padding: 12px 12px 6px;
 }
-@media (min-width: 1440px) {
-  .speedtest {
-    --chart-h: 420px;
+
+.speed__header {
+  display: grid;
+  gap: 8px;
+  justify-items: center;
+  grid-template-rows: auto auto auto;
+}
+
+.speed__progress {
+  font-size: 12px;
+  line-height: 1.2;
+  display: grid;
+  gap: 4px;
+  text-align: center;
+}
+
+.speed__grid {
+  display: grid;
+  gap: 12px;
+  margin-top: 10px;
+  grid-template-columns: 1fr;
+}
+@media (min-width: 1024px) {
+  .speed__grid {
+    grid-template-columns: 1fr 1fr;
   }
 }
-.speedtest__chart {
-  height: var(--chart-h);
+
+.panel {
+  border: 1px solid var(--green);
+  border-radius: 8px;
+  padding: 8px;
+  position: relative;
+  background: rgba(0, 0, 0, 0.18);
+}
+.panel__title {
+  font-size: 12px;
+  margin-bottom: 6px;
+  opacity: 0.9;
+}
+.chart {
+  height: 340px;
   position: relative;
   overflow: hidden;
+}
+@media (min-width: 1440px) {
+  .chart {
+    height: 380px;
+  }
+}
+@media (max-width: 768px) {
+  .chart {
+    height: 260px;
+  }
+}
+.panel__peak {
+  position: absolute;
+  right: 10px;
+  top: 8px;
+  font-size: 12px;
+  color: #5f5;
+  opacity: 0.9;
+}
+
+.speed__legend {
+  display: flex;
+  justify-content: center;
+  padding: 6px 0 2px;
+}
+.legend {
+  font-size: 12px;
+  opacity: 0.85;
+}
+.dot {
+  display: inline-block;
+  width: 10px;
+  height: 10px;
+  border-radius: 2px;
+  margin-right: 6px;
+  vertical-align: middle;
+}
+.dot--single {
+  background: #2ff;
+  border: 1px solid #0aa;
+}
+.dot--multi {
+  background: #f3f;
+  border: 1px solid #a0a;
+}
+.sep {
+  opacity: 0.5;
+  margin: 0 8px;
+}
+
+.mono {
+  font-family: ui-monospace, Menlo, Consolas, monospace;
 }
 
 .icon,
@@ -89,19 +178,13 @@
   line-height: 1;
   vertical-align: baseline;
 }
+
 .badge {
   font-size: 12px;
   padding: 2px 6px;
-  border: 1px solid #0a3;
+  border: 1px solid var(--green);
   border-radius: 6px;
   background: rgba(0, 128, 0, 0.12);
-}
-
-.speedtest__progress {
-  font-size: 12px;
-  line-height: 1.2;
-  display: grid;
-  gap: 4px;
 }
 
 .bars {
@@ -120,10 +203,6 @@
   width: 100%;
   position: relative;
 }
-.bar--upload {
-  background: #f3f;
-  border-color: #a0a;
-}
 .value {
   position: absolute;
   transform: translateY(-100%);
@@ -133,15 +212,15 @@
 
 .seg {
   display: inline-flex;
-  border: 1px solid #0a3;
+  border: 1px solid var(--green);
   border-radius: 8px;
   overflow: hidden;
-  background: rgba(0, 128, 0, 0.06);
+  background: rgba(0, 128, 0, 0.08);
 }
 .seg__btn {
   padding: 6px 10px;
   font-size: 12px;
-  border-right: 1px solid #0a3;
+  border-right: 1px solid var(--green);
   cursor: pointer;
   background: transparent;
 }
@@ -149,13 +228,10 @@
   border-right: none;
 }
 .seg__btn.is-active {
-  background: rgba(0, 255, 128, 0.12);
+  background: var(--green-soft);
 }
 
 @media (max-width: 640px) {
-  .speedtest {
-    --chart-h: 260px;
-  }
   .seg__btn {
     padding: 4px 8px;
     font-size: 11px;


### PR DESCRIPTION
## Summary
- restructure speed test card with segmented controls, progress display, and legend
- add responsive panels for download/upload charts with peak indicators
- streamline chart component to render bars with conditional labels

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68961fb74c50832ab0ad23b26f74577d