### PR TITLE
Refine dashboard layout and speed test visuals

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,6 +8,8 @@
       "name": "frontend",
       "version": "0.0.0",
       "dependencies": {
+        "chart.js": "^4.5.0",
+        "chartjs-plugin-datalabels": "^2.2.0",
         "react": "^19.1.0",
         "react-dom": "^19.1.0"
       },
@@ -1052,6 +1054,12 @@
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
+    },
+    "node_modules/@kurkle/color": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@kurkle/color/-/color-0.3.4.tgz",
+      "integrity": "sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w==",
+      "license": "MIT"
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -2574,6 +2582,27 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/chart.js": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.5.0.tgz",
+      "integrity": "sha512-aYeC/jDgSEx8SHWZvANYMioYMZ2KX02W6f6uVfyteuCGcadDLcYVHdfdygsTQkQ4TKn5lghoojAsPj5pu0SnvQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@kurkle/color": "^0.3.0"
+      },
+      "engines": {
+        "pnpm": ">=8"
+      }
+    },
+    "node_modules/chartjs-plugin-datalabels": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/chartjs-plugin-datalabels/-/chartjs-plugin-datalabels-2.2.0.tgz",
+      "integrity": "sha512-14ZU30lH7n89oq+A4bWaJPnAG8a7ZTk7dKf48YAzMvJjQtjrgg5Dpk9f+LbjCF6bpx3RAGTeL13IXpKQYyRvlw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "chart.js": ">=3.0.0"
       }
     },
     "node_modules/chownr": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,6 +10,8 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "chart.js": "^4.5.0",
+    "chartjs-plugin-datalabels": "^2.2.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0"
   },

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -581,7 +581,7 @@ function App() {
         <AsciiLogo />
         <div className="dashboard">
           {info ? (
-            <TestSection title="Your Connection Info">
+            <TestSection title="Your Connection Info" className="card--info">
               <div>IP: {maskIp(info.client_ip)}</div>
               <div>Location: {info.location || 'Unknown'}</div>
               <div>ASN: {info.asn || 'Unknown'}</div>
@@ -596,12 +596,12 @@ function App() {
               </div>
             </TestSection>
           ) : (
-            <TestSection title="Your Connection Info">
+            <TestSection title="Your Connection Info" className="card--info">
               <div>No info available</div>
             </TestSection>
           )}
 
-          <TestSection title="Recent Tests">
+          <TestSection title="Recent Tests" className="card--recent">
           {sortedRecords.length > 0 ? (
             <div className="overflow-x-auto">
               <table className="min-w-full text-sm text-left border border-green-600 border-collapse">
@@ -688,7 +688,7 @@ function App() {
           )}
         </TestSection>
 
-        <TestSection title="Auto Ping Test">
+        <TestSection title="Auto Ping Test" className="card--ping">
           {pingOutput && (
             <div>
               <pre className="whitespace-pre-wrap text-left font-mono bg-[rgb(0,40,0)] bg-opacity-70 p-4 rounded">
@@ -708,7 +708,7 @@ function App() {
           )}
         </TestSection>
 
-        <TestSection title="Traceroute">
+        <TestSection title="Traceroute" className="card--trace">
           {traceOutput && (
             <div>
               <pre className="whitespace-pre-wrap text-left font-mono bg-[rgb(0,40,0)] bg-opacity-70 p-4 rounded">
@@ -728,7 +728,7 @@ function App() {
           )}
         </TestSection>
 
-        <section className="card card--speed card--wide">
+        <section className="card card--speed">
           <header className="speed__header">
             <h2 className="card__title">Speed Test</h2>
             <div className="seg">
@@ -791,13 +791,13 @@ function App() {
               <div>
                 Download:
                 <span className="mono"> {formatProgress(downloadProgress)}</span>{' '}
-                <span className="icon">⬇</span>
+                <i className="icon-dl" aria-hidden="true"></i>
                 <span className="mono"> {currentDownloadSpeed.toFixed(2)} Mbps</span>
               </div>
               <div>
                 Upload:
                 <span className="mono"> {formatProgress(uploadProgress)}</span>{' '}
-                <span className="icon">⬆</span>
+                <i className="icon-ul" aria-hidden="true"></i>
                 <span className="mono"> {currentUploadSpeed.toFixed(2)} Mbps</span>
               </div>
             </div>
@@ -809,7 +809,7 @@ function App() {
                 <div className="panel__title">Download</div>
                 <SpeedChart
                   speeds={downloadSpeeds}
-                  color={currentThreads === 1 ? '#2ff' : '#f3f'}
+                  multi={currentThreads > 1}
                 />
                 <div className="panel__peak">
                   {Math.max(...downloadSpeeds).toFixed(2)} Mbps
@@ -821,7 +821,7 @@ function App() {
                 <div className="panel__title">Upload</div>
                 <SpeedChart
                   speeds={uploadSpeeds}
-                  color={currentThreads === 1 ? '#2ff' : '#f3f'}
+                  multi={currentThreads > 1}
                 />
                 <div className="panel__peak">
                   {Math.max(...uploadSpeeds).toFixed(2)} Mbps

--- a/frontend/src/SpeedChart.tsx
+++ b/frontend/src/SpeedChart.tsx
@@ -1,30 +1,93 @@
+import { useEffect, useRef } from 'react';
+import { Chart, registerables } from 'chart.js';
+import ChartDataLabels from 'chartjs-plugin-datalabels';
+
+Chart.register(...registerables, ChartDataLabels);
+
 interface SpeedChartProps {
   speeds: number[];
-  color: string;
+  multi: boolean;
 }
 
-export default function SpeedChart({ speeds, color }: SpeedChartProps) {
-  const maxSpeed = Math.max(...speeds, 1);
+export default function SpeedChart({ speeds, multi }: SpeedChartProps) {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
 
-  return (
-    <div className="chart">
-      <div className="bars">
-        {speeds.map((s, i) => (
-          <div
-            key={i}
-            className="bar"
-            style={{
-              height: `${(s / maxSpeed) * 100}%`,
-              background: color,
-              borderColor: color,
-            }}
-          >
-            {(s / maxSpeed) * 100 > 5 && (
-              <span className="value">{s.toFixed(0)}</span>
-            )}
-          </div>
-        ))}
-      </div>
-    </div>
-  );
+  useEffect(() => {
+    if (!canvasRef.current) return;
+    const ctx = canvasRef.current.getContext('2d');
+    if (!ctx) return;
+
+    const gradient = ctx.createLinearGradient(0, 0, 0, canvasRef.current.height);
+    if (multi) {
+      gradient.addColorStop(0, 'rgba(229,58,214,0.95)');
+      gradient.addColorStop(1, 'rgba(229,58,214,0.25)');
+    } else {
+      gradient.addColorStop(0, 'rgba(39,232,229,0.95)');
+      gradient.addColorStop(1, 'rgba(39,232,229,0.25)');
+    }
+
+    const borderColor = multi ? '#b824a9' : '#16c3bf';
+
+    const labels = speeds.map((_, i) => `${i + 1}`);
+
+    const chart = new Chart(ctx, {
+      type: 'bar',
+      data: {
+        labels,
+        datasets: [
+          {
+            data: speeds,
+            backgroundColor: gradient,
+            borderColor,
+            borderWidth: 1.5,
+            borderRadius: 5,
+          },
+        ],
+      },
+      options: {
+        maintainAspectRatio: false,
+        layout: { padding: { left: 8, right: 8, top: 8, bottom: 6 } },
+        plugins: {
+          legend: { display: false },
+          tooltip: {
+            mode: 'index',
+            intersect: false,
+            backgroundColor: 'rgba(0,0,0,.75)',
+            borderColor: '#2f9e68',
+            borderWidth: 1,
+          },
+          datalabels: {
+            color: '#d7ffe9',
+            anchor: 'end',
+            align: 'end',
+            offset: 4,
+            font: { size: 10, weight: 600 },
+            formatter: (value: number, context) => {
+              const y = context.chart.scales.y.getPixelForValue(value);
+              return y < 20 ? '' : value;
+            },
+          },
+        },
+        scales: {
+          x: {
+            grid: { display: false },
+            ticks: { color: '#9fffcf', font: { size: 11 } },
+          },
+          y: {
+            beginAtZero: true,
+            grid: { color: 'rgba(26,255,122,.10)' },
+            ticks: { color: '#8deabf', font: { size: 11 } },
+          },
+        },
+        elements: {
+          bar: { barPercentage: 0.5, categoryPercentage: 0.55 },
+        },
+      },
+    });
+
+    return () => chart.destroy();
+  }, [speeds, multi]);
+
+  return <canvas ref={canvasRef} className="chart" />;
 }
+

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -15,8 +15,11 @@
   line-height: 1.4;
   --container: 1280px;
   --gap: 16px;
-  --green: #0a3;
-  --green-soft: rgba(0, 255, 128, 0.12);
+  --green: #1aff7a;
+  --green-weak: rgba(26,255,122,.12);
+  --btn-border: #2f9e68;
+  --btn-bg: rgba(0,0,0,.25);
+  --btn-active: linear-gradient(180deg, rgba(26,255,122,.25), rgba(26,255,122,.12));
 }
 
 .app {
@@ -43,18 +46,20 @@
 
 .dashboard {
   display: grid;
-  grid-template-columns: 1fr;
-  grid-auto-rows: minmax(120px, auto);
+  grid-template-areas:
+    "info"
+    "recent"
+    "ping"
+    "trace"
+    "speed";
   gap: var(--gap);
 }
-@media (min-width: 1024px) {
-  .dashboard {
-    grid-template-columns: 1fr 1fr;
-  }
-  .card--wide {
-    grid-column: 1 / span 2;
-  }
-}
+
+.card--info   { grid-area: info; }
+.card--recent { grid-area: recent; }
+.card--ping   { grid-area: ping; }
+.card--trace  { grid-area: trace; }
+.card--speed  { grid-area: speed; }
 
 .card {
   background: rgba(0, 0, 0, 0.3);
@@ -71,7 +76,7 @@
 }
 
 .card--speed {
-  padding: 12px 12px 6px;
+  padding: 12px;
 }
 
 .speed__header {
@@ -155,12 +160,12 @@
   vertical-align: middle;
 }
 .dot--single {
-  background: #2ff;
-  border: 1px solid #0aa;
+  background: #27E8E5;
+  border: 1px solid #16c3bf;
 }
 .dot--multi {
-  background: #f3f;
-  border: 1px solid #a0a;
+  background: #E53AD6;
+  border: 1px solid #b824a9;
 }
 .sep {
   opacity: 0.5;
@@ -187,57 +192,44 @@
   background: rgba(0, 128, 0, 0.12);
 }
 
-.bars {
-  display: grid;
-  grid-template-columns: repeat(8, minmax(0, 1fr));
-  gap: 8px;
-  height: 100%;
-  align-items: end;
+.icon-dl, .icon-ul{
+  width:12px; height:12px; display:inline-block; position:relative; margin:0 4px;
+  filter: drop-shadow(0 0 4px rgba(26,255,122,.6));
 }
-.bar {
-  background: #2ff;
-  border: 2px solid #0a8;
-  border-radius: 4px 4px 0 0;
-  max-width: 72px;
-  justify-self: center;
-  width: 100%;
-  position: relative;
+.icon-dl::before, .icon-ul::before{
+  content:''; position:absolute; inset:0; border:1.5px solid #1aff7a; border-radius:2px;
+  transform: rotate(45deg);
 }
-.value {
-  position: absolute;
-  transform: translateY(-100%);
-  font-size: 12px;
-  color: #0f6;
+.icon-dl::after{
+  content:''; position:absolute; left:3px; right:3px; bottom:-2px; height:1.5px; background:#1aff7a;
+}
+.icon-ul::after{
+  content:''; position:absolute; left:-2px; top:3px; bottom:3px; width:1.5px; background:#1aff7a;
 }
 
-.seg {
-  display: inline-flex;
-  border: 1px solid var(--green);
-  border-radius: 8px;
-  overflow: hidden;
-  background: rgba(0, 128, 0, 0.08);
+.seg{
+  display:inline-flex; border:1px solid var(--btn-border);
+  border-radius:10px; overflow:hidden; background: var(--btn-bg);
+  box-shadow: inset 0 0 0 1px rgba(26,255,122,.06);
 }
-.seg__btn {
-  padding: 6px 10px;
-  font-size: 12px;
-  border-right: 1px solid var(--green);
-  cursor: pointer;
-  background: transparent;
+.seg__btn{
+  padding:6px 12px; font-size:12px; color:#fff;
+  background: transparent; border:none; cursor:pointer;
+  border-right:1px solid var(--btn-border);
+  letter-spacing:.2px;
 }
-.seg__btn:last-child {
-  border-right: none;
-}
-.seg__btn.is-active {
-  background: var(--green-soft);
+.seg__btn:last-child{ border-right:none; }
+.seg__btn:hover{ background: rgba(255,255,255,.04); }
+.seg__btn.is-active{
+  background: var(--btn-active);
+  color:#fff; font-weight:600;
+  text-shadow: 0 0 6px rgba(26,255,122,.6);
 }
 
 @media (max-width: 640px) {
   .seg__btn {
     padding: 4px 8px;
     font-size: 11px;
-  }
-  .bars {
-    grid-template-columns: repeat(4, 1fr);
   }
 }
 


### PR DESCRIPTION
## Summary
- stack connection info and recent tests vertically via grid areas
- refresh speed test controls with neon styling and vector icons
- rebuild speed charts using Chart.js with slimmer cyber-themed bars

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689624024fdc832a9a0789726cae34a6