### PR TITLE
fix: resolve Chart.js bar options build error

### DIFF
--- a/frontend/src/SpeedChart.tsx
+++ b/frontend/src/SpeedChart.tsx
@@ -41,6 +41,8 @@ export default function SpeedChart({ speeds, multi }: SpeedChartProps) {
             borderColor,
             borderWidth: 1.5,
             borderRadius: 5,
+            barPercentage: 0.5,
+            categoryPercentage: 0.55,
           },
         ],
       },
@@ -78,9 +80,6 @@ export default function SpeedChart({ speeds, multi }: SpeedChartProps) {
             grid: { color: 'rgba(26,255,122,.10)' },
             ticks: { color: '#8deabf', font: { size: 11 } },
           },
-        },
-        elements: {
-          bar: { barPercentage: 0.5, categoryPercentage: 0.55 },
         },
       },
     });


### PR DESCRIPTION
## Summary
- move bar percentage options into dataset configuration for Chart.js v4

## Testing
- `npm --prefix frontend run lint`
- `npm --prefix frontend run build`
- `pytest backend`


------
https://chatgpt.com/codex/tasks/task_e_68962614fdf8832a8e2a3c359ca15d4f