### PR TITLE
fix: correct axis configuration for speedtest chart

### DIFF
--- a/frontend/src/SpeedChart.tsx
+++ b/frontend/src/SpeedChart.tsx
@@ -47,6 +47,7 @@ export default function SpeedChart({ speeds, multi }: SpeedChartProps) {
         ],
       },
       options: {
+        indexAxis: 'x',
         maintainAspectRatio: false,
         layout: { padding: { left: 8, right: 8, top: 8, bottom: 6 } },
         plugins: {
@@ -72,6 +73,7 @@ export default function SpeedChart({ speeds, multi }: SpeedChartProps) {
         },
         scales: {
           x: {
+            type: 'category',
             grid: { display: false },
             ticks: { color: '#9fffcf', font: { size: 11 } },
           },


### PR DESCRIPTION
## Summary
- ensure speed chart uses category x-axis with explicit orientation

## Testing
- `npm run lint`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689627e85cf0832aa9555e8f94ec2687