### PR TITLE
Add date field and markdown export

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -469,6 +469,7 @@ def probe_page(request: Request, db: Session = Depends(get_db)):
             .replace(minute=0, second=0, microsecond=0)
             .strftime("%I:00%p")
         )
+        existing.date = to_shanghai(now).strftime("%Y-%m-%d")
         db_record = existing
     else:
         now = datetime.utcnow()
@@ -478,6 +479,7 @@ def probe_page(request: Request, db: Session = Depends(get_db)):
             .replace(minute=0, second=0, microsecond=0)
             .strftime("%I:00%p")
         )
+        data["date"] = to_shanghai(now).strftime("%Y-%m-%d")
         db_record = models.TestRecord(**data)
         db.add(db_record)
 
@@ -632,6 +634,7 @@ def create_test(
                 .replace(minute=0, second=0, microsecond=0)
                 .strftime("%I:00%p")
             ),
+            "date": to_shanghai(now).strftime("%Y-%m-%d"),
         }
         return schemas.TestRecord(id=0, **mapped)
 
@@ -691,6 +694,7 @@ def create_test(
             .replace(minute=0, second=0, microsecond=0)
             .strftime("%I:00%p")
         )
+        existing.date = to_shanghai(now).strftime("%Y-%m-%d")
 
         db.commit()
         db.refresh(existing)
@@ -715,6 +719,7 @@ def create_test(
             .replace(minute=0, second=0, microsecond=0)
             .strftime("%I:00%p")
         ),
+        "date": to_shanghai(now).strftime("%Y-%m-%d"),
     }
     if speedtest_type == "single":
         mapped["single_dl_mbps"] = dl
@@ -772,6 +777,7 @@ def admin_create_test(
             .strftime("%I:00%p")
         ),
     )
+    data.setdefault("date", to_shanghai(now).strftime("%Y-%m-%d"))
     existing = (
         db.query(models.TestRecord)
         .filter(models.TestRecord.client_ip == data.get("client_ip"))

--- a/backend/models.py
+++ b/backend/models.py
@@ -8,6 +8,7 @@ class TestRecord(Base):
 
     id = Column(Integer, primary_key=True, index=True)
     timestamp = Column(DateTime, default=datetime.utcnow)
+    date = Column(String)
     client_ip = Column(String)
     user_agent = Column(String)
     location = Column(String)

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -24,6 +24,7 @@ class TestRecordBase(BaseModel):
     iperf_result: str | None = None
     test_target: str | None = None
     time_hour: str | None = None
+    date: str | None = None
 
 
 class TestRecordCreate(BaseModel):

--- a/backend/templates/admin.html
+++ b/backend/templates/admin.html
@@ -19,6 +19,7 @@
             <label>Location: <input name="location"></label><br>
             <label>ASN: <input name="asn"></label><br>
             <label>ISP: <input name="isp"></label><br>
+            <label>Date: <input name="date" type="date"></label><br>
             <label>Ping Avg(ms): <input name="ping_ms" type="number" step="0.01"></label><br>
             <label>Ping Min(ms): <input name="ping_min_ms" type="number" step="0.01"></label><br>
             <label>Ping Max(ms): <input name="ping_max_ms" type="number" step="0.01"></label><br>
@@ -39,6 +40,7 @@
                 <tr>
                     <th><input type="checkbox" id="selectAll"></th>
                     <th>ID</th>
+                    <th>Date</th>
                     <th>Time</th>
                     <th>Client IP</th>
                     <th>Location</th>
@@ -92,6 +94,7 @@ async function loadRecords(page = 1) {
         tr.innerHTML = `
             <td><input type="checkbox" value="${rec.id}"></td>
             <td>${rec.id}</td>
+            <td>${rec.date || ''}</td>
             <td>${rec.time_hour || ''}</td>
             <td>${rec.client_ip || ''}</td>
             <td>${rec.location || ''}</td>
@@ -143,6 +146,7 @@ document.getElementById('recordsTable').addEventListener('click', async e => {
             form.location.value = rec.location || '';
             form.asn.value = rec.asn || '';
             form.isp.value = rec.isp || '';
+            form.date.value = rec.date || '';
             form.ping_ms.value = rec.ping_ms ?? '';
             form.ping_min_ms.value = rec.ping_min_ms ?? '';
             form.ping_max_ms.value = rec.ping_max_ms ?? '';
@@ -189,8 +193,8 @@ document.getElementById('nextPage').addEventListener('click', () => {
 
 document.getElementById('exportExcel').addEventListener('click', () => {
     if (!currentRecords.length) return;
-    const header = ['Client IP','Time','Location','ASN','ISP','Ping Avg(ms)','Ping Min(ms)','Ping Max(ms)','Single DL(Mbps)','Single UL(Mbps)','Multi DL(Mbps)','Multi UL(Mbps)','Target'];
-    const rows = currentRecords.map(r => [r.client_ip || '', r.time_hour || '', r.location || '', r.asn || '', r.isp || '', r.ping_ms ?? '', r.ping_min_ms ?? '', r.ping_max_ms ?? '', r.single_dl_mbps ?? '', r.single_ul_mbps ?? '', r.multi_dl_mbps ?? '', r.multi_ul_mbps ?? '', r.test_target || '']);
+    const header = ['Client IP','Date','Time','Location','ASN','ISP','Ping Avg(ms)','Ping Min(ms)','Ping Max(ms)','Single DL(Mbps)','Single UL(Mbps)','Multi DL(Mbps)','Multi UL(Mbps)','Target'];
+    const rows = currentRecords.map(r => [r.client_ip || '', r.date || '', r.time_hour || '', r.location || '', r.asn || '', r.isp || '', r.ping_ms ?? '', r.ping_min_ms ?? '', r.ping_max_ms ?? '', r.single_dl_mbps ?? '', r.single_ul_mbps ?? '', r.multi_dl_mbps ?? '', r.multi_ul_mbps ?? '', r.test_target || '']);
     const csv = [header.join(','), ...rows.map(row => row.join(','))].join('\n');
     const blob = new Blob([csv], {type: 'text/csv;charset=utf-8;'});
     const url = URL.createObjectURL(blob);


### PR DESCRIPTION
## Summary
- track test date in database and admin UI
- show ASN/ISP and eight-thread speeds in Recent Tests; update ping header
- add copy-as-Markdown button for sharing test results

## Testing
- `pytest`
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_6896a39bb364832ab45914f2afdd41b7