### PR TITLE
Improve markdown copy formatting and handle timeouts

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -247,12 +247,14 @@ def _ping(host: str) -> float | None:
             ["ping", "-c", "1", host],
             capture_output=True,
             text=True,
-            timeout=5,
+            timeout=10,
         )
         if result.returncode == 0:
             match = re.search(r"time[=<]([0-9.]+) ms", result.stdout)
             if match:
                 return float(match.group(1))
+    except subprocess.TimeoutExpired:
+        return None
     except Exception:
         pass
     return None
@@ -843,7 +845,7 @@ def run_ping(host: str, count: int = 4):
             ["ping", "-c", str(count), host],
             capture_output=True,
             text=True,
-            timeout=10,
+            timeout=20,
         )
         if result.returncode == 0:
             data = {"output": result.stdout}
@@ -863,6 +865,8 @@ def run_ping(host: str, count: int = 4):
         return {"error": result.stderr or "Ping failed"}
     except FileNotFoundError:
         return {"error": "ping command not found"}
+    except subprocess.TimeoutExpired:
+        return {"error": "Ping timed out"}
     except Exception as exc:
         return {"error": str(exc)}
 
@@ -875,7 +879,7 @@ def run_traceroute(host: str, download: bool = False):
             ["traceroute", host],
             capture_output=True,
             text=True,
-            timeout=30,
+            timeout=60,
         )
         if result.returncode != 0:
             return {"error": result.stderr or "Traceroute failed"}
@@ -891,6 +895,8 @@ def run_traceroute(host: str, download: bool = False):
         return {"output": result.stdout}
     except FileNotFoundError:
         return {"error": "traceroute command not found"}
+    except subprocess.TimeoutExpired as exc:
+        return {"error": "Traceroute timed out", "output": exc.output or ""}
     except Exception as exc:
         return {"error": str(exc)}
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -225,7 +225,7 @@ function App() {
     const singleUp = info?.single_ul_mbps?.toFixed(2) ?? '';
     const multiDown = info?.multi_dl_mbps?.toFixed(2) ?? '';
     const multiUp = info?.multi_ul_mbps?.toFixed(2) ?? '';
-    return `#VPS.TOWN NODE Probe\n\n##Your Connection Info\nIP: ${maskedIp}\nLocation: ${info?.location || 'Unknown'}\nASN: ${info?.asn || 'Unknown'}\nISP: ${info?.isp || 'Unknown'}\n\n##Auto Ping Test\n\n\u0060\u0060\u0060\n${pingText}\n\u0060\u0060\u0060\n\n##Traceroute\n\n\u0060\u0060\u0060\n${traceText}\n\u0060\u0060\u0060\n\n##Speed TEST\n\n|Type|Download (Mbps)|Upload (Mbps)|\n|---|---|---|\n|Single Thread|${singleDown}|${singleUp}|\n|Eight Threads|${multiDown}|${multiUp}|\n`;
+    return `# VPS.TOWN NODE Probe\n\n## Your Connection Info\n- IP: ${maskedIp}\n- Location: ${info?.location || 'Unknown'}\n- ASN: ${info?.asn || 'Unknown'}\n- ISP: ${info?.isp || 'Unknown'}\n\n## Auto Ping Test\n\n\u0060\u0060\u0060\n${pingText}\n\u0060\u0060\u0060\n\n## Traceroute\n\n\u0060\u0060\u0060\n${traceText}\n\u0060\u0060\u0060\n\n## Speed Test\n\n| Type | Download (Mbps) | Upload (Mbps) |\n| --- | --- | --- |\n| Single Thread | ${singleDown} | ${singleUp} |\n| Eight Threads | ${multiDown} | ${multiUp} |\n`;
   };
 
   const copyMarkdown = async () => {


### PR DESCRIPTION
## Summary
- Beautify copied markdown output with proper headings and bullet lists
- Extend ping/traceroute timeouts and return clearer timeout errors

## Testing
- `pytest -q`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6896af9078b0832a8b3eda9b421a0af6