### PR TITLE
feat: add data usage note to probe loading

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -138,6 +138,7 @@ _   _           _        _____           _
         <span class="sr-only">正在加载，请稍候</span>
         <div class="spinner" aria-hidden="true"></div>
         <div class="loading-text">测试中，请不要关闭或刷新。</div>
+        <div class="loading-text">测试大概消耗300Mb流量</div>
       </div>
     </div>
     <script type="module" src="/src/main.tsx"></script>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -637,6 +637,7 @@ function App() {
           <span className="sr-only">正在加载，请稍候</span>
           <div className="w-12 h-12 border-4 border-green-400/30 border-t-green-400 rounded-full animate-spin will-change-[transform] motion-reduce:animate-none" />
           <div className="text-lg animate-pulse motion-reduce:animate-none">测试中，请不要关闭或刷新。</div>
+          <div className="text-lg animate-pulse motion-reduce:animate-none">测试大概消耗300Mb流量</div>
           {loadingMsg && (
             <div className="text-sm animate-pulse motion-reduce:animate-none">{loadingMsg}</div>
           )}


### PR DESCRIPTION
## Summary
- show additional 300Mb data usage note during probe loading

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6896b12c6424832a8ac6f753a48148dc