### PR TITLE
Fix markdown headings in copy feature

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -225,7 +225,7 @@ function App() {
     const singleUp = info?.single_ul_mbps?.toFixed(2) ?? '';
     const multiDown = info?.multi_dl_mbps?.toFixed(2) ?? '';
     const multiUp = info?.multi_ul_mbps?.toFixed(2) ?? '';
-    return `# VPS.TOWN NODE Probe\n\n## Your Connection Info\n- IP: ${maskedIp}\n- Location: ${info?.location || 'Unknown'}\n- ASN: ${info?.asn || 'Unknown'}\n- ISP: ${info?.isp || 'Unknown'}\n\n## Auto Ping Test\n\n\u0060\u0060\u0060\n${pingText}\n\u0060\u0060\u0060\n\n## Traceroute\n\n\u0060\u0060\u0060\n${traceText}\n\u0060\u0060\u0060\n\n## Speed Test\n\n| Type | Download (Mbps) | Upload (Mbps) |\n| --- | --- | --- |\n| Single Thread | ${singleDown} | ${singleUp} |\n| Eight Threads | ${multiDown} | ${multiUp} |\n`;
+    return `# VPS.TOWN NODE Probe\n\n# Your Connection Info\n- IP: ${maskedIp}\n- Location: ${info?.location || 'Unknown'}\n- ASN: ${info?.asn || 'Unknown'}\n- ISP: ${info?.isp || 'Unknown'}\n\n# Auto Ping Test\n\n\u0060\u0060\u0060\n${pingText}\n\u0060\u0060\u0060\n\n# Traceroute\n\n\u0060\u0060\u0060\n${traceText}\n\u0060\u0060\u0060\n\n# Speed Test\n\n| Type | Download (Mbps) | Upload (Mbps) |\n| --- | --- | --- |\n| Single Thread | ${singleDown} | ${singleUp} |\n| Eight Threads | ${multiDown} | ${multiUp} |\n`;
   };
 
   const copyMarkdown = async () => {


### PR DESCRIPTION
## Summary
- unify copied markdown headings to use `# ` syntax

## Testing
- `npm run lint`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6896b1df3710832a97d354de85e0c94c