### PR TITLE
feat: format chart labels with two decimal places

### DIFF
--- a/frontend/src/SpeedChart.tsx
+++ b/frontend/src/SpeedChart.tsx
@@ -42,7 +42,7 @@ export default function SpeedChart({ speeds, multi }: SpeedChartProps) {
             font: { size: 10, weight: 600 },
             formatter: (value: number, context) => {
               const y = context.chart.scales.y.getPixelForValue(value);
-              return y < 20 ? '' : value;
+              return y < 20 ? '' : value.toFixed(2);
             },
           },
         },


### PR DESCRIPTION
## Summary
- format bar chart labels to show two decimal places

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6896b755cf5c832a970245db1e325b4e