### PR TITLE
fix: restore centered layout and chart sizing

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -664,7 +664,7 @@ function App() {
 
   return (
     <div className="min-h-screen bg-gradient-to-b from-[#0a1a0a] to-[#021505] text-[var(--text)]">
-      <main className="mx-auto container max-w-screen-xl px-4 lg:px-6 space-y-6">
+      <main className="app space-y-6">
         <AsciiLogo />
         <div className="text-center">
           <button

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -137,7 +137,8 @@
   opacity: 0.9;
 }
 .chart {
-  flex: 1;
+  width: 100%;
+  height: 100%;
   position: relative;
   overflow: hidden;
 }


### PR DESCRIPTION
## Summary
- restore centered wide-screen layout using global container
- ensure speed test chart fills container to avoid downward bars

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6897105b4174832a8c442ca0b58935d4