### PR TITLE
fix: reset speedtest chart and frame recent tests

### DIFF
--- a/backend/templates/index.html
+++ b/backend/templates/index.html
@@ -80,7 +80,7 @@
     </ul>
 
     <h2>Recent Tests</h2>
-    <table>
+    <table border="1">
       <thead>
         <tr>
           <th>IP</th>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -568,6 +568,10 @@ function App() {
     const uploadSetter =
       threads === 1 ? setSingleUploadSpeeds : setMultiUploadSpeeds;
 
+    // Clear previous speed records to reset chart axis
+    downloadSetter([]);
+    uploadSetter([]);
+
     const speedtestPromise = (async () => {
       const down = await downloadWithProgress(
         downloadSize,
@@ -699,7 +703,7 @@ function App() {
 
             <TestSection title="Recent Tests">
               {sortedRecords.length > 0 ? (
-                <div className="max-h-60 overflow-auto">
+                <div className="max-h-60 overflow-auto rounded border border-emerald-900/40">
                   <table className="min-w-full text-xs leading-6 text-left">
                     <thead className="sticky top-0 bg-emerald-900/20 backdrop-blur">
                       <tr className="text-emerald-300">


### PR DESCRIPTION
## Summary
- reset speed test speed arrays before each run to prevent ever-growing y-axis
- wrap recent test results in a bordered table

## Testing
- `npm run lint`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68971cbadbb4832ab8377cc69cabdc14