### PR TITLE
feat: align ping and traceroute cards

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -55,6 +55,17 @@
   gap: var(--gap);
 }
 
+@media (min-width: 768px) {
+  .dashboard {
+    grid-template-columns: 1fr 1fr;
+    grid-template-areas:
+      "info info"
+      "recent recent"
+      "ping trace"
+      "speed speed";
+  }
+}
+
 .card--info   { grid-area: info; }
 .card--recent { grid-area: recent; }
 .card--ping   { grid-area: ping; }


### PR DESCRIPTION
## Summary
- show Auto Ping Test and Traceroute cards side-by-side on wider screens

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68980ffadca8832abe17c1df629fca75