### PR TITLE
docs: clarify project tech stack in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,12 @@
 
 [中文文档](README.zh.md)
 
+## Tech Stack
+
+- **Backend**: Python FastAPI with SQLite located in `backend/`
+- **Frontend**: React + TypeScript built with Vite and Tailwind CSS located in `frontend/`
+- **Deployment**: Docker and Docker Compose for packaging and one‑click setup
+
 ## Features
 
 - ICMP ping with latency measurement
@@ -17,9 +23,6 @@
 - One‑click deployment via Docker Compose or a prebuilt image
 
 ## Development
-
-- **Backend**: FastAPI with SQLite located in `backend/`
-- **Frontend**: React + Vite + Tailwind CSS located in `frontend/`
 
 ### Quick start
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -1,5 +1,11 @@
 [English](README.md)
 
+## 技术栈
+
+- **后端**：Python FastAPI + SQLite，位于 `backend/`
+- **前端**：React + TypeScript，使用 Vite 与 Tailwind CSS 构建，位于 `frontend/`
+- **部署**：通过 Docker 与 Docker Compose 进行封装并一键启动
+
 ## 功能特性
 
 - 支持 ICMP Ping 延迟测试
@@ -13,9 +19,6 @@
 - 通过 Docker Compose 或预构建镜像一键部署
 
 ## 开发环境
-
-- **后端**：位于 `backend/` 的 FastAPI + SQLite
-- **前端**：位于 `frontend/` 的 React + Vite + Tailwind CSS
 
 ### 快速开始
 


### PR DESCRIPTION
## Summary
- add dedicated Tech Stack sections in English and Chinese READMEs
- highlight backend, frontend, and deployment technologies

## Testing
- `pip install -r backend/requirements.txt`
- `cd backend && pytest`
- `cd frontend && npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689d3aecdfc0832abba9c5aff8a0d6df